### PR TITLE
refactor: 상품 관리 기능 및 product/category컨트롤러 응답 리팩토링

### DIFF
--- a/src/main/java/com/fourweekdays/fourweekdays/category/controller/CategoryController.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/category/controller/CategoryController.java
@@ -20,10 +20,9 @@ public class CategoryController {
 
     // 카테고리 등록
     @PostMapping
-    public ResponseEntity<BaseResponse<String>> register(@RequestBody CategoryCreateDto dto) {
-        categoryService.register(dto);
-        return ResponseEntity.ok(BaseResponse.success("등록 완료"));
-
+    public ResponseEntity<BaseResponse<Long>> register(@RequestBody CategoryCreateDto dto) {
+        Long saveId = categoryService.register(dto);
+        return ResponseEntity.ok(BaseResponse.success(saveId));
     }
 
     // 카테고리 전체 조회

--- a/src/main/java/com/fourweekdays/fourweekdays/category/dto/request/CategoryCreateDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/category/dto/request/CategoryCreateDto.java
@@ -1,7 +1,10 @@
 package com.fourweekdays.fourweekdays.category.dto.request;
 
 import com.fourweekdays.fourweekdays.category.model.Category;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder

--- a/src/main/java/com/fourweekdays/fourweekdays/category/dto/response/CategoryReadDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/category/dto/response/CategoryReadDto.java
@@ -1,7 +1,10 @@
 package com.fourweekdays.fourweekdays.category.dto.response;
 
 import com.fourweekdays.fourweekdays.category.model.Category;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder

--- a/src/main/java/com/fourweekdays/fourweekdays/category/model/Category.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/category/model/Category.java
@@ -2,7 +2,10 @@ package com.fourweekdays.fourweekdays.category.model;
 
 import com.fourweekdays.fourweekdays.common.BaseEntity;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/fourweekdays/fourweekdays/category/service/CategoryService.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/category/service/CategoryService.java
@@ -6,6 +6,7 @@ import com.fourweekdays.fourweekdays.category.model.Category;
 import com.fourweekdays.fourweekdays.category.repository.CategoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -17,6 +18,7 @@ public class CategoryService {
     private final CategoryRepository categoryRepository;
 
     // 카테고리 등록
+    @Transactional
     public Long register(CategoryCreateDto dto) {
         Category parent = null;
 
@@ -33,6 +35,7 @@ public class CategoryService {
     }
 
     // 카테고리 전체 조회
+    @Transactional(readOnly = true)
     public List<CategoryReadDto> getCategoryList() {
         return categoryRepository.findAll().stream()
                 .map(CategoryReadDto::from)

--- a/src/main/java/com/fourweekdays/fourweekdays/common/BaseEntity.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/common/BaseEntity.java
@@ -8,7 +8,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Getter
 @EntityListeners(AuditingEntityListener.class)
@@ -17,8 +17,8 @@ public class BaseEntity {
 
     @Column(updatable = false)
     @CreatedDate
-    private LocalDateTime createdAt;
+    private LocalDate createdAt;
 
     @LastModifiedDate
-    private LocalDateTime updatedAt;
+    private LocalDate updatedAt;
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/product/controller/ProductController.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/product/controller/ProductController.java
@@ -2,8 +2,11 @@ package com.fourweekdays.fourweekdays.product.controller;
 
 import com.fourweekdays.fourweekdays.common.BaseResponse;
 import com.fourweekdays.fourweekdays.common.BaseResponseStatus;
-import com.fourweekdays.fourweekdays.product.dto.response.ProductReadDto;
 import com.fourweekdays.fourweekdays.product.dto.request.ProductCreateDto;
+import com.fourweekdays.fourweekdays.product.dto.request.ProductStatusUpdateDto;
+import com.fourweekdays.fourweekdays.product.dto.response.ProductReadDto;
+import com.fourweekdays.fourweekdays.product.dto.response.ProductStatusResponseDto;
+import com.fourweekdays.fourweekdays.product.model.ProductStatusHistory;
 import com.fourweekdays.fourweekdays.product.service.ProductService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -21,9 +24,9 @@ public class ProductController {
 
     // 상품 등록
     @PostMapping
-    public ResponseEntity<BaseResponse<String>> register(@RequestBody ProductCreateDto dto) {
-        productservice.register(dto);
-        return ResponseEntity.ok(BaseResponse.success("등록 완료"));
+    public ResponseEntity<BaseResponse<Long>> register(@RequestBody ProductCreateDto dto) {
+        Long saveId = productservice.register(dto);
+        return ResponseEntity.ok(BaseResponse.success(saveId));
     }
 
     // 상품 전체 조회
@@ -42,5 +45,16 @@ public class ProductController {
                     .body(BaseResponse.error(BaseResponseStatus.PRODUCT_NOT_FOUND));
         }
         return ResponseEntity.ok(BaseResponse.success(productDto));
+    }
+
+    // 상품 상태 변경
+    @PatchMapping("/{id}")
+    public ResponseEntity<BaseResponse<ProductStatusResponseDto>> updateStatus(
+            @PathVariable Long id,
+            @RequestBody ProductStatusUpdateDto dto
+    ) {
+        ProductStatusHistory history = productservice.updateProductStatus(id, dto);
+        ProductStatusResponseDto response = ProductStatusResponseDto.from(history);
+        return ResponseEntity.ok(BaseResponse.success(response));
     }
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/product/dto/request/ProductCreateDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/product/dto/request/ProductCreateDto.java
@@ -43,7 +43,7 @@ public class ProductCreateDto {
                 .marginRate(this.marginRate)
                 .currency(this.currency)
                 .specification(this.specification)
-                .expirationAt(this.expirationAt != null ? this.expirationAt.atStartOfDay() : null)
+                .expirationAt(this.expirationAt != null ? LocalDate.from(this.expirationAt.atStartOfDay()) : null)
                 .originCountry(this.originCountry)
                 .category(category) // 연관관계 주입
                 .build();

--- a/src/main/java/com/fourweekdays/fourweekdays/product/dto/response/ProductStatusResponseDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/product/dto/response/ProductStatusResponseDto.java
@@ -1,0 +1,33 @@
+package com.fourweekdays.fourweekdays.product.dto.response;
+
+import com.fourweekdays.fourweekdays.product.model.ProductStatusHistory;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProductStatusResponseDto {
+    private Long productId;
+    private String productName;
+    private String oldStatus;
+    private String newStatus;
+    private String changedBy;
+    private LocalDate changedAt;
+
+    public static ProductStatusResponseDto from(ProductStatusHistory history) {
+        return ProductStatusResponseDto.builder()
+                .productId(history.getProduct().getId())
+                .productName(history.getProduct().getProductName())
+                .oldStatus(history.getOldStatus() != null ? history.getOldStatus().name() : null)
+                .newStatus(history.getNewStatus().name())
+                .changedBy(history.getChangedBy())
+                .changedAt(history.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/fourweekdays/fourweekdays/product/model/Product.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/product/model/Product.java
@@ -9,6 +9,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Builder
@@ -20,7 +22,6 @@ public class Product extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id; // 상품 ID
-
     private String productCode; // SKU/바코드
     private String productName; // 상품명
     private int costPrice;      // 매입가 (원가)
@@ -35,14 +36,16 @@ public class Product extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ProductStatus status;   // 현재 상품 상태
 
-    public void updateStatus(ProductStatus newStatus){
+    public void updateStatus(ProductStatus newStatus) {
         this.status = newStatus;
     }
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id")
-    private Category category; // 상품 카테고리
-//
+    private Category category;
+
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL)
+    private List<ProductStatusHistory> histories = new ArrayList<>();
 //    @ManyToOne
 //    @JoinColumn(name = "partner_id")
 //    private Vendor vendor;   // 공급업체 (Vendor)

--- a/src/main/java/com/fourweekdays/fourweekdays/product/model/ProductStatus.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/product/model/ProductStatus.java
@@ -1,5 +1,6 @@
 package com.fourweekdays.fourweekdays.product.model;
 
+// 시스템에 필요한 워크플로우 상수로 별도 테이블X
 public enum ProductStatus {
     RECEIVED("입고"),
     INSPECTING("검수중"),
@@ -9,7 +10,7 @@ public enum ProductStatus {
 
     private final String label;
 
-    ProductStatus(String label){
+    ProductStatus(String label) {
         this.label = label;
     }
 


### PR DESCRIPTION
# 🧩 Issue Number
#18 상품 상태 관리
#8 카테고리 등록
#14 상품등록

## 📝 요약
refactor: 상품 상태 관리 비즈니스 로직 구현
refactor: 상품 등록 컨트롤러 register메서드 응답 수정
refactor: 카테고리 등록 컨트롤러 register메서드 응답 수정

## 🔍 변경 사항
close #18 상품 상태 관리

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수 했는가?
- [x] 커밋 내용에 시크릿 키 등의 공유되지 말아야 할 것들을 제거 했는가?

## 💬 기타 공유사항
상품 상태 변경시 ProductStatusHistory를 통해 변경 이력 남게 해두었으며 Product 엔티티와 연관관계 맺어뒀습니다.
ProductStatusHistory의 경우 시스템에 필요한 워크플로우 상수로 별도 테이블 만들지 않고 ProductStatus를 enum으로 뒀습니다.