### PR TITLE
fix: vendor address문제 해결

### DIFF
--- a/src/main/java/com/fourweekdays/fourweekdays/common/Address.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/common/Address.java
@@ -1,7 +1,15 @@
 package com.fourweekdays.fourweekdays.common;
 
 import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Embeddable
 public class Address {
 

--- a/src/main/java/com/fourweekdays/fourweekdays/vendor/model/dto/request/VendorCreateDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/vendor/model/dto/request/VendorCreateDto.java
@@ -1,5 +1,6 @@
 package com.fourweekdays.fourweekdays.vendor.model.dto.request;
 
+import com.fourweekdays.fourweekdays.common.Address;
 import com.fourweekdays.fourweekdays.vendor.model.entity.Vendor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,15 +12,27 @@ public class VendorCreateDto {
     private String name;
     private String phoneNumber;
     private String email;
-    private String address;
+    private String zipcode; // 우편번호
+    private String street; // 도로명 주소
+    private String detail; // 상세 주소 (건물명, 호수 등)
+    private String city; // 도시
+    private String country; // 국가 코드 (예: KR, US)
 
     public Vendor toEntity() {
+        Address address = Address.builder()
+                .zipcode(this.zipcode)
+                .street(this.street)
+                .detail(this.detail)
+                .city(this.city)
+                .country(this.country)
+                .build();
+
         return Vendor.builder()
                 .businessRegistrationNo(this.businessRegistrationNo)
                 .name(this.name)
                 .phoneNumber(this.phoneNumber)
                 .email(this.email)
-//                .address()
+                .address(address)
                 .build();
     }
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/vendor/model/dto/request/VendorUpdateDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/vendor/model/dto/request/VendorUpdateDto.java
@@ -1,5 +1,6 @@
 package com.fourweekdays.fourweekdays.vendor.model.dto.request;
 
+import com.fourweekdays.fourweekdays.common.Address;
 import com.fourweekdays.fourweekdays.vendor.model.entity.Vendor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,16 +13,28 @@ public class VendorUpdateDto {
     private String name;
     private String phoneNumber;
     private String email;
-    private String address;
+    private String zipcode; // 우편번호
+    private String street; // 도로명 주소
+    private String detail; // 상세 주소 (건물명, 호수 등)
+    private String city; // 도시
+    private String country; // 국가 코드 (예: KR, US)
 
     public Vendor toEntity() {
+        Address address = Address.builder()
+                .zipcode(this.zipcode)
+                .street(this.street)
+                .detail(this.detail)
+                .city(this.city)
+                .country(this.country)
+                .build();
+
         return Vendor.builder()
                 .id(this.id)
                 .businessRegistrationNo(this.businessRegistrationNo)
                 .name(this.name)
                 .phoneNumber(this.phoneNumber)
                 .email(this.email)
-//                .address()
+                .address(address)
                 .build();
     }
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/vendor/model/dto/response/VendorReadDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/vendor/model/dto/response/VendorReadDto.java
@@ -14,7 +14,7 @@ public class VendorReadDto {
     private String name;
     private String phoneNumber;
     private String email;
-    private String address;
+    private Address address;
 
     public static VendorReadDto from(Vendor entity) {
         return  VendorReadDto.builder()
@@ -23,7 +23,7 @@ public class VendorReadDto {
                 .name(entity.getName())
                 .phoneNumber(entity.getPhoneNumber())
                 .email(entity.getEmail())
-//                .address(entity.getAddress())
+                .address(entity.getAddress())
                 .build();
     }
 }


### PR DESCRIPTION
# 🧩 Issue Number
#41 #42 #43 #44

## 📝 요약
> fix: address 문제 해결

## 🔍 변경 사항
- dto에서 주석으로 처리해둔 address 사용되게 변경
- 관련 이슈: #41 #42 #43 #44

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수 했는가?
- [x] 커밋 내용에 시크릿 키 등의 공유되지 말아야 할 것들을 제거 했는가?

## 💬 기타 공유사항
>     public Vendor toEntity() {
        Address address = Address.builder()
                .zipcode(this.zipcode)
                .street(this.street)
                .detail(this.detail)
                .city(this.city)
                .country(this.country)
                .build();
이 부분을 엔티티가 처리하게 만들어야 하는지 중요한건 아니라고 생각하지만 컨벤션 최대한 맞추고 싶어서 물어봅니다