### PR TITLE
feat: entity mapping

### DIFF
--- a/src/main/java/com/fourweekdays/fourweekdays/common/vo/Address.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/common/vo/Address.java
@@ -1,4 +1,4 @@
-package com.fourweekdays.fourweekdays.common;
+package com.fourweekdays.fourweekdays.common.vo;
 
 import jakarta.persistence.Embeddable;
 

--- a/src/main/java/com/fourweekdays/fourweekdays/franchise/FranchiseStore.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/franchise/FranchiseStore.java
@@ -1,6 +1,6 @@
 package com.fourweekdays.fourweekdays.franchise;
 
-import com.fourweekdays.fourweekdays.common.Address;
+import com.fourweekdays.fourweekdays.common.vo.Address;
 import com.fourweekdays.fourweekdays.common.BaseEntity;
 import jakarta.persistence.*;
 

--- a/src/main/java/com/fourweekdays/fourweekdays/inbound/controller/InboundController.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/inbound/controller/InboundController.java
@@ -1,10 +1,10 @@
-package com.fourweekdays.fourweekdays.Inbound.controller;
+package com.fourweekdays.fourweekdays.inbound.controller;
 
-import com.fourweekdays.fourweekdays.Inbound.model.dto.request.InboundCreateDto;
-import com.fourweekdays.fourweekdays.Inbound.model.dto.request.InboundUpdateDto;
-import com.fourweekdays.fourweekdays.Inbound.model.dto.response.InboundListDto;
-import com.fourweekdays.fourweekdays.Inbound.model.dto.response.InboundReadDto;
-import com.fourweekdays.fourweekdays.Inbound.service.InboundService;
+import com.fourweekdays.fourweekdays.inbound.model.dto.request.InboundCreateDto;
+import com.fourweekdays.fourweekdays.inbound.model.dto.request.InboundUpdateDto;
+import com.fourweekdays.fourweekdays.inbound.model.dto.response.InboundListDto;
+import com.fourweekdays.fourweekdays.inbound.model.dto.response.InboundReadDto;
+import com.fourweekdays.fourweekdays.inbound.service.InboundService;
 import com.fourweekdays.fourweekdays.common.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/fourweekdays/fourweekdays/inbound/exception/InboundException.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/inbound/exception/InboundException.java
@@ -1,4 +1,4 @@
-package com.fourweekdays.fourweekdays.Inbound.exception;
+package com.fourweekdays.fourweekdays.inbound.exception;
 
 import com.fourweekdays.fourweekdays.global.exception.BaseException;
 import com.fourweekdays.fourweekdays.global.exception.ExceptionType;

--- a/src/main/java/com/fourweekdays/fourweekdays/inbound/exception/InboundExceptionType.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/inbound/exception/InboundExceptionType.java
@@ -1,4 +1,4 @@
-package com.fourweekdays.fourweekdays.Inbound.exception;
+package com.fourweekdays.fourweekdays.inbound.exception;
 
 import com.fourweekdays.fourweekdays.global.exception.ExceptionType;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/fourweekdays/fourweekdays/inbound/model/dto/request/InboundCreateDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/inbound/model/dto/request/InboundCreateDto.java
@@ -1,29 +1,24 @@
-package com.fourweekdays.fourweekdays.Inbound.model.dto.request;
+package com.fourweekdays.fourweekdays.inbound.model.dto.request;
 
-import com.fourweekdays.fourweekdays.Inbound.model.entity.Inbound;
-import com.fourweekdays.fourweekdays.Inbound.model.entity.InboundStatus;
+import com.fourweekdays.fourweekdays.inbound.model.entity.Inbound;
 import com.fourweekdays.fourweekdays.member.Member;
 import com.fourweekdays.fourweekdays.purchaseorder.PurchaseOrder;
 import lombok.Getter;
 
 @Getter
-public class InboundUpdateDto {
-    private Long id;
+public class InboundCreateDto {
     private Integer memberId;
     private Integer purchaseOrderId;
     private Integer quantity;
-    private InboundStatus status;
 
     public Inbound toEntity() {
         Member member = Member.builder().id(memberId).build();
         PurchaseOrder purchaseOrder = PurchaseOrder.builder().id(purchaseOrderId).build();
 
         return Inbound.builder()
-                .id(this.id)
                 .member(member)
                 .purchaseOrder(purchaseOrder)
                 .quantity(Long.valueOf(this.quantity))
-                .status(this.status)
                 .build();
     }
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/inbound/model/dto/request/InboundDeleteDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/inbound/model/dto/request/InboundDeleteDto.java
@@ -1,6 +1,6 @@
-package com.fourweekdays.fourweekdays.Inbound.model.dto.request;
+package com.fourweekdays.fourweekdays.inbound.model.dto.request;
 
-import com.fourweekdays.fourweekdays.Inbound.model.entity.Inbound;
+import com.fourweekdays.fourweekdays.inbound.model.entity.Inbound;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/com/fourweekdays/fourweekdays/inbound/model/dto/request/InboundUpdateDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/inbound/model/dto/request/InboundUpdateDto.java
@@ -1,24 +1,29 @@
-package com.fourweekdays.fourweekdays.Inbound.model.dto.request;
+package com.fourweekdays.fourweekdays.inbound.model.dto.request;
 
-import com.fourweekdays.fourweekdays.Inbound.model.entity.Inbound;
+import com.fourweekdays.fourweekdays.inbound.model.entity.Inbound;
+import com.fourweekdays.fourweekdays.inbound.model.entity.InboundStatus;
 import com.fourweekdays.fourweekdays.member.Member;
 import com.fourweekdays.fourweekdays.purchaseorder.PurchaseOrder;
 import lombok.Getter;
 
 @Getter
-public class InboundCreateDto {
+public class InboundUpdateDto {
+    private Long id;
     private Integer memberId;
     private Integer purchaseOrderId;
     private Integer quantity;
+    private InboundStatus status;
 
     public Inbound toEntity() {
         Member member = Member.builder().id(memberId).build();
         PurchaseOrder purchaseOrder = PurchaseOrder.builder().id(purchaseOrderId).build();
 
         return Inbound.builder()
+                .id(this.id)
                 .member(member)
                 .purchaseOrder(purchaseOrder)
                 .quantity(Long.valueOf(this.quantity))
+                .status(this.status)
                 .build();
     }
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/inbound/model/dto/response/InboundListDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/inbound/model/dto/response/InboundListDto.java
@@ -1,6 +1,6 @@
-package com.fourweekdays.fourweekdays.Inbound.model.dto.response;
+package com.fourweekdays.fourweekdays.inbound.model.dto.response;
 
-import com.fourweekdays.fourweekdays.Inbound.model.entity.Inbound;
+import com.fourweekdays.fourweekdays.inbound.model.entity.Inbound;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/com/fourweekdays/fourweekdays/inbound/model/dto/response/InboundReadDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/inbound/model/dto/response/InboundReadDto.java
@@ -1,6 +1,6 @@
-package com.fourweekdays.fourweekdays.Inbound.model.dto.response;
+package com.fourweekdays.fourweekdays.inbound.model.dto.response;
 
-import com.fourweekdays.fourweekdays.Inbound.model.entity.Inbound;
+import com.fourweekdays.fourweekdays.inbound.model.entity.Inbound;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/com/fourweekdays/fourweekdays/inbound/model/entity/Inbound.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/inbound/model/entity/Inbound.java
@@ -1,4 +1,4 @@
-package com.fourweekdays.fourweekdays.Inbound.model.entity;
+package com.fourweekdays.fourweekdays.inbound.model.entity;
 
 import com.fourweekdays.fourweekdays.common.BaseEntity;
 import com.fourweekdays.fourweekdays.member.Member;

--- a/src/main/java/com/fourweekdays/fourweekdays/inbound/model/entity/InboundStatus.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/inbound/model/entity/InboundStatus.java
@@ -1,4 +1,4 @@
-package com.fourweekdays.fourweekdays.Inbound.model.entity;
+package com.fourweekdays.fourweekdays.inbound.model.entity;
 
 public enum InboundStatus {
     REQUESTED, RECEIVED, COMPLETED

--- a/src/main/java/com/fourweekdays/fourweekdays/inbound/repository/InboundRepository.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/inbound/repository/InboundRepository.java
@@ -1,6 +1,6 @@
-package com.fourweekdays.fourweekdays.Inbound.repository;
+package com.fourweekdays.fourweekdays.inbound.repository;
 
-import com.fourweekdays.fourweekdays.Inbound.model.entity.Inbound;
+import com.fourweekdays.fourweekdays.inbound.model.entity.Inbound;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface InboundRepository extends JpaRepository<Inbound, Long> {

--- a/src/main/java/com/fourweekdays/fourweekdays/inbound/service/InboundService.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/inbound/service/InboundService.java
@@ -1,12 +1,12 @@
-package com.fourweekdays.fourweekdays.Inbound.service;
+package com.fourweekdays.fourweekdays.inbound.service;
 
-import com.fourweekdays.fourweekdays.Inbound.model.dto.request.InboundCreateDto;
-import com.fourweekdays.fourweekdays.Inbound.model.dto.request.InboundDeleteDto;
-import com.fourweekdays.fourweekdays.Inbound.model.dto.request.InboundUpdateDto;
-import com.fourweekdays.fourweekdays.Inbound.model.dto.response.InboundReadDto;
-import com.fourweekdays.fourweekdays.Inbound.model.dto.response.InboundListDto;
-import com.fourweekdays.fourweekdays.Inbound.model.entity.Inbound;
-import com.fourweekdays.fourweekdays.Inbound.repository.InboundRepository;
+import com.fourweekdays.fourweekdays.inbound.model.dto.request.InboundCreateDto;
+import com.fourweekdays.fourweekdays.inbound.model.dto.request.InboundDeleteDto;
+import com.fourweekdays.fourweekdays.inbound.model.dto.request.InboundUpdateDto;
+import com.fourweekdays.fourweekdays.inbound.model.dto.response.InboundReadDto;
+import com.fourweekdays.fourweekdays.inbound.model.dto.response.InboundListDto;
+import com.fourweekdays.fourweekdays.inbound.model.entity.Inbound;
+import com.fourweekdays.fourweekdays.inbound.repository.InboundRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;

--- a/src/main/java/com/fourweekdays/fourweekdays/notification/Notification.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/notification/Notification.java
@@ -1,6 +1,6 @@
 package com.fourweekdays.fourweekdays.notification;
 
-import com.fourweekdays.fourweekdays.Inbound.model.entity.Inbound;
+import com.fourweekdays.fourweekdays.inbound.model.entity.Inbound;
 import com.fourweekdays.fourweekdays.common.BaseEntity;
 import com.fourweekdays.fourweekdays.inventory.Inventory;
 import com.fourweekdays.fourweekdays.member.model.entity.Member;

--- a/src/main/java/com/fourweekdays/fourweekdays/product/model/Product.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/product/model/Product.java
@@ -1,52 +1,36 @@
 package com.fourweekdays.fourweekdays.product.model;
 
-import com.fourweekdays.fourweekdays.category.model.Category;
 import com.fourweekdays.fourweekdays.common.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
+import lombok.*;
 
 @Entity
 @Builder
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Product extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id; // 상품 ID
-    private String productCode; // SKU/바코드
-    private String productName; // 상품명
-    private int costPrice;      // 매입가 (원가)
-    private int listPrice;      // 소비자가 (리스트가)
-    private int wholesalePrice; // 도매가 (가맹점 공급가)
-    private int marginRate;     // 마진율 (%)
-    private String currency; // 금액 단위 (KRW, USD, JPY 등)
-    private String specification; // 규격 (예: 500ml, Box 20개입)
-    private LocalDate expirationAt; // 유통기한
-    private String originCountry; // 원산지
+    private Long id;
 
-    @Enumerated(EnumType.STRING)
-    private ProductStatus status;   // 현재 상품 상태
+    @Column(nullable = false, length = 200)
+    private String name;
 
-    public void updateStatus(ProductStatus newStatus) {
-        this.status = newStatus;
-    }
+    @Column(nullable = false, unique = true, length = 50)
+    private String productCode;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "category_id")
-    private Category category;
+    private Long unitPrice; // 단가
 
-    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL)
-    private List<ProductStatusHistory> histories = new ArrayList<>();
-//    @ManyToOne
-//    @JoinColumn(name = "partner_id")
-//    private Vendor vendor;   // 공급업체 (Vendor)
+    @Column(length = 1000)
+    private String description;
+
+    private ProductStatus status;
+
+//    @Column(nullable = false, unique = true, length = 50)
+//    private String barcode; // 바코드 추후 구현
+
+    // ===== 연관 관계 ===== //
+    // ===== 로직 ===== //
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/product/model/Product.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/product/model/Product.java
@@ -1,6 +1,7 @@
 package com.fourweekdays.fourweekdays.product.model;
 
 import com.fourweekdays.fourweekdays.common.BaseEntity;
+import com.fourweekdays.fourweekdays.vendor.model.entity.Vendor;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -13,6 +14,7 @@ public class Product extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "product_id")
     private Long id;
 
     @Column(nullable = false, length = 200)
@@ -21,12 +23,20 @@ public class Product extends BaseEntity {
     @Column(nullable = false, unique = true, length = 50)
     private String productCode;
 
+    @Column(length = 50)
+    private String unit; // 단위 (예: EA, Box ...)
+
     private Long unitPrice; // 단가
 
     @Column(length = 1000)
     private String description;
 
-    private ProductStatus status;
+    @Enumerated(EnumType.STRING)
+    private ProductStatus status; //ACTIVE, INACTIVE, DISCONTINUED
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "vendor_id")
+    private Vendor vendor; // 공급업체
 
 //    @Column(nullable = false, unique = true, length = 50)
 //    private String barcode; // 바코드 추후 구현

--- a/src/main/java/com/fourweekdays/fourweekdays/product/model/ProductStatus.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/product/model/ProductStatus.java
@@ -2,6 +2,6 @@ package com.fourweekdays.fourweekdays.product.model;
 
 public enum ProductStatus {
     ACTIVE,
-    INACTIVE, // 재고 부족 등으로 일시적 0
+    INACTIVE, // 품절
     DISCONTINUED // 단종
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/product/model/ProductStatus.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/product/model/ProductStatus.java
@@ -1,17 +1,7 @@
 package com.fourweekdays.fourweekdays.product.model;
 
-// 시스템에 필요한 워크플로우 상수로 별도 테이블X
 public enum ProductStatus {
-    RECEIVED("입고"),
-    INSPECTING("검수중"),
-    INSPECTED("검수 완료"),
-    STORING("적치중"),
-    APPROVED("승인");
-
-    private final String label;
-
-    ProductStatus(String label) {
-        this.label = label;
-    }
-
+    ACTIVE,
+    INACTIVE, // 재고 부족 등으로 일시적 0
+    DISCONTINUED // 단종
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/tasks/Task.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/tasks/Task.java
@@ -1,6 +1,6 @@
 package com.fourweekdays.fourweekdays.tasks;
 
-import com.fourweekdays.fourweekdays.Inbound.model.entity.Inbound;
+import com.fourweekdays.fourweekdays.inbound.model.entity.Inbound;
 import com.fourweekdays.fourweekdays.common.BaseEntity;
 import com.fourweekdays.fourweekdays.inventory.Inventory;
 import com.fourweekdays.fourweekdays.member.model.entity.Member;

--- a/src/main/java/com/fourweekdays/fourweekdays/vendor/model/dto/response/VendorReadDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/vendor/model/dto/response/VendorReadDto.java
@@ -1,8 +1,6 @@
 package com.fourweekdays.fourweekdays.vendor.model.dto.response;
 
-import com.fourweekdays.fourweekdays.common.Address;
 import com.fourweekdays.fourweekdays.vendor.model.entity.Vendor;
-import jakarta.persistence.Embedded;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/com/fourweekdays/fourweekdays/vendor/model/entity/Vendor.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/vendor/model/entity/Vendor.java
@@ -1,31 +1,52 @@
 package com.fourweekdays.fourweekdays.vendor.model.entity;
 
-import com.fourweekdays.fourweekdays.common.Address;
 import com.fourweekdays.fourweekdays.common.BaseEntity;
+import com.fourweekdays.fourweekdays.product.model.Product;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
 @Builder
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class Vendor extends BaseEntity {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "vendor_id")
     private Long id;
 
-    private String businessRegistrationNo; // 사업자 등록 번호
+    @Column(nullable = false, unique = true, length = 50)
+    private String vendorCode; // 공급업체 코드 (V-001, V-002 등)
 
+    @Column(nullable = false, length = 200)
     private String name;
+
+    @Column(length = 20)
     private String phoneNumber;
+
+    @Column(length = 100)
     private String email;
 
-    @Embedded
-    private Address address;
+    private String description; // 업체 설명 및 비고
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private VendorStatus status; // ACTIVE, INACTIVE, SUSPEND
+
+    @OneToMany(mappedBy = "vendor", fetch = FetchType.LAZY) // TODO: think CASCADE
+    private List<Product> productList = new ArrayList<>();
+
+//    @Column(length = 200)
+//    private String employee; // 담당자
+
+    // ===== 비즈니스 로직 ===== //
+    public boolean canOrder() {
+        return this.status == VendorStatus.ACTIVE;
+    }
 
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/vendor/model/entity/Vendor.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/vendor/model/entity/Vendor.java
@@ -1,5 +1,6 @@
 package com.fourweekdays.fourweekdays.vendor.model.entity;
 
+import com.fourweekdays.fourweekdays.common.vo.Address;
 import com.fourweekdays.fourweekdays.common.BaseEntity;
 import com.fourweekdays.fourweekdays.product.model.Product;
 import jakarta.persistence.*;
@@ -37,6 +38,9 @@ public class Vendor extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private VendorStatus status; // ACTIVE, INACTIVE, SUSPEND
+
+    @Embedded
+    private Address address;
 
     @OneToMany(mappedBy = "vendor", fetch = FetchType.LAZY) // TODO: think CASCADE
     private List<Product> productList = new ArrayList<>();

--- a/src/main/java/com/fourweekdays/fourweekdays/vendor/model/entity/VendorStatus.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/vendor/model/entity/VendorStatus.java
@@ -1,0 +1,7 @@
+package com.fourweekdays.fourweekdays.vendor.model.entity;
+
+public enum VendorStatus {
+    ACTIVE, // 활성
+    INACTIVE, // 비활성
+    SUSPENDED // 거래 정지
+}

--- a/src/main/java/com/fourweekdays/fourweekdays/warehouse/Warehouse.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/warehouse/Warehouse.java
@@ -1,6 +1,6 @@
 package com.fourweekdays.fourweekdays.warehouse;
 
-import com.fourweekdays.fourweekdays.common.Address;
+import com.fourweekdays.fourweekdays.common.vo.Address;
 import com.fourweekdays.fourweekdays.common.BaseEntity;
 import jakarta.persistence.*;
 


### PR DESCRIPTION
# 🧩 Issue Number
- #76 

## 📝 요약
엔티티 설계를 간소화 하고 연관관계를 설정했습니다. 


## 🔍 변경 사항
- 상품 엔티티 재정의
- 공급 업체 엔티티 재정의 
- 연관 관계 설정
- 상품 상태 재정의 
- close #76 

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수 했는가?
- [x] 커밋 내용에 시크릿 키 등의 공유되지 말아야 할 것들을 제거 했는가?

## 💬 기타 공유사항
우선 어제 멘토링 내용대로 상품의 상태를 간소화 했습니다. 
```Java
public enum ProductStatus {
    ACTIVE,
    INACTIVE, // 품절
    DISCONTINUED // 단종
}
```

추가적으로 상품 카테고리 간소화를 위해서 특정 상품 쪽으로 넘어가는거 생각해주세요.

