### PR TITLE
refactor: 입고 엔티티를 재설계하고 발주와 연관관계를 설정한다.

### DIFF
--- a/src/main/java/com/fourweekdays/fourweekdays/inbound/model/entity/Inbound.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/inbound/model/entity/Inbound.java
@@ -1,34 +1,50 @@
 package com.fourweekdays.fourweekdays.inbound.model.entity;
 
 import com.fourweekdays.fourweekdays.common.BaseEntity;
-import com.fourweekdays.fourweekdays.member.Member;
-import com.fourweekdays.fourweekdays.purchaseorder.PurchaseOrder;
+import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrder;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
 @Builder
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class Inbound extends BaseEntity {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    private Long quantity; // 입고 수량
+    
+    @Column(nullable = false)
+    private String inboundNumber;
 
     @Enumerated(EnumType.STRING)
     private InboundStatus status;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Member member;
+    // TODO: Member와 연관관계
+    private String managerName; // 입고 담당자
+    private String workerName; // 작업 담당자
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "purchaseOrder_id")
+    private LocalDateTime receivedDate; // 입고 시간
+    private LocalDateTime completedDate; // 작업 완료시간
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "purchase_order_id")
     private PurchaseOrder purchaseOrder;
+
+    @OneToMany(mappedBy = "inbound")
+    private List<InboundProductItem> items = new ArrayList<>();
+
+    private String description; // 비고
+    
+//    private String invoiceNumber; // 송장 번호
+//    private String receivedBy; // 입고 담당자
+//    private String driverName; // 배달 기사
+//    private String driverPhoneNumber;
+
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/inbound/model/entity/InboundProductItem.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/inbound/model/entity/InboundProductItem.java
@@ -1,0 +1,55 @@
+package com.fourweekdays.fourweekdays.inbound.model.entity;
+
+
+import com.fourweekdays.fourweekdays.common.BaseEntity;
+import com.fourweekdays.fourweekdays.product.model.Product;
+import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrderProductItem;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class InboundProductItem extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "inbound_product_item_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "inbound_id", nullable = false)
+    private Inbound inbound;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "purchase_order_product_item_id", nullable = false)
+    private PurchaseOrderProductItem purchaseOrderProductItem;
+
+    @Column(nullable = false)
+    private Integer receivedQuantity; // 입고 수량
+
+    @Column(length = 50, nullable = true)
+    private String lotNumber; // 로트번호
+    private String locationCode; // 적재위치 (A-01-01) TODO: Location 엔티티 or VO 격상
+
+    @Column
+    private LocalDate expirationDate; // TODO: 이게 필요한가?
+
+    @Column(length = 1000)
+    private String description; // 비고
+
+    // ===== 연관관계 편의 메서드 ===== //
+    // ... Inbound 할당 메서드 ...
+
+    // ===== 비즈니스 로직 ===== //
+    // ... 입고 수량 검증 메서드 ...
+    // ... 발주 항목 입고 수량 업데이트 메서드 ...
+}

--- a/src/main/java/com/fourweekdays/fourweekdays/inbound/model/entity/InboundStatus.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/inbound/model/entity/InboundStatus.java
@@ -1,5 +1,19 @@
 package com.fourweekdays.fourweekdays.inbound.model.entity;
 
+
+import lombok.Getter;
+
+@Getter
 public enum InboundStatus {
-    REQUESTED, RECEIVED, COMPLETED
+
+    SCHEDULED("입고예정"),
+    RECEIVING("입고중"),
+    COMPLETED("입고완료"),
+    CANCELLED("취소");
+
+    private final String description;
+
+    InboundStatus(String description) {
+        this.description = description;
+    }
 }


### PR DESCRIPTION
# 🧩 Issue Number
- #80 

## 📝 요약
입고 엔티티를 재설계하고 발주와 연관관계를 설정한다.

## 🔍 변경 사항
- refactor: 입고 엔티티를 재설계한다.
- feat: 입고 상품 엔티티를 구현한다.
- feat: 입고-발주 연관관계를 설정한다.
- close #80 

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수 했는가?
- [x] 커밋 내용에 시크릿 키 등의 공유되지 말아야 할 것들을 제거 했는가?

## 💬 기타 공유사항
- 입고, 입고 상태 그리고 입고 상품을 정의하고 구현했습니다. 
- 입고 상품은 입고(Inbound)-상품(Product)의 중간 테이블로 발주 상품이 모두 입고 되지 않는 구조를 가정하고 만들었습니다. 
다만 발주-입고의 경우 간단한 구현을 위해 1:1 매핑 관계를 갖도록 구현해놨으므로 이후에 프로젝트의 상태에 따라서 변경이 필요할 것 같습니다. 
- 또한 현재는 해당 입고에 대해서 담당자 / 작업자가 단순 String으로 이름만 명시되는 구조를 갖는데 이후에 Member와의 연관관계를 생각해봐야 할 것 같습니다. 
