### PR TITLE
Feat: product dto for swagger

### DIFF
--- a/src/main/java/com/fourweekdays/fourweekdays/product/controller/ProductController.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/product/controller/ProductController.java
@@ -3,10 +3,8 @@ package com.fourweekdays.fourweekdays.product.controller;
 import com.fourweekdays.fourweekdays.common.BaseResponse;
 import com.fourweekdays.fourweekdays.common.BaseResponseStatus;
 import com.fourweekdays.fourweekdays.product.dto.request.ProductCreateDto;
-import com.fourweekdays.fourweekdays.product.dto.request.ProductStatusUpdateDto;
+import com.fourweekdays.fourweekdays.product.dto.request.ProductUpdateDto;
 import com.fourweekdays.fourweekdays.product.dto.response.ProductReadDto;
-import com.fourweekdays.fourweekdays.product.dto.response.ProductStatusResponseDto;
-import com.fourweekdays.fourweekdays.product.model.ProductStatusHistory;
 import com.fourweekdays.fourweekdays.product.service.ProductService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,41 +18,46 @@ import java.util.List;
 @RequestMapping("/api/product")
 public class ProductController {
 
-    private final ProductService productservice;
+    private final ProductService productService;
 
     // 상품 등록
     @PostMapping
     public ResponseEntity<BaseResponse<Long>> register(@RequestBody ProductCreateDto dto) {
-        Long saveId = productservice.register(dto);
+        Long saveId = productService.createProduct(dto);
         return ResponseEntity.ok(BaseResponse.success(saveId));
     }
 
     // 상품 전체 조회
     @GetMapping
     public ResponseEntity<BaseResponse<List<ProductReadDto>>> getProductList() {
-        List<ProductReadDto> productList = productservice.getProductList();
+        List<ProductReadDto> productList = productService.getProductList();
         return ResponseEntity.ok(BaseResponse.success(productList));
     }
 
     // 상품 상세 조회
     @GetMapping("/{id}")
     public ResponseEntity<BaseResponse<ProductReadDto>> getProductDetails(@PathVariable Long id) {
-        ProductReadDto productDto = productservice.getProductDetails(id);
+        ProductReadDto productDto = productService.getProductDetails(id);
         if (productDto == null) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
                     .body(BaseResponse.error(BaseResponseStatus.PRODUCT_NOT_FOUND));
         }
         return ResponseEntity.ok(BaseResponse.success(productDto));
     }
-
-    // 상품 상태 변경
+    
     @PatchMapping("/{id}")
-    public ResponseEntity<BaseResponse<ProductStatusResponseDto>> updateStatus(
-            @PathVariable Long id,
-            @RequestBody ProductStatusUpdateDto dto
-    ) {
-        ProductStatusHistory history = productservice.updateProductStatus(id, dto);
-        ProductStatusResponseDto response = ProductStatusResponseDto.from(history);
-        return ResponseEntity.ok(BaseResponse.success(response));
+    public ResponseEntity<BaseResponse<Long>> updateProduct(@PathVariable Long id,
+                                                            @RequestBody ProductUpdateDto requestDto) {
+        return ResponseEntity.ok(BaseResponse.success(productService.update(id, requestDto)));
     }
+
+
+//    // 상품 상태 변경
+//    @PatchMapping("/{id}")
+//    public ResponseEntity<BaseResponse<ProductStatusResponseDto>> updateStatus(@PathVariable Long id, 
+//                                                                               @RequestBody ProductStatusUpdateDto dto) {
+//        ProductStatusHistory history = productservice.updateProductStatus(id, dto);
+//        ProductStatusResponseDto response = ProductStatusResponseDto.from(history);
+//        return ResponseEntity.ok(BaseResponse.success(response));
+//    }
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/product/dto/request/ProductCreateDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/product/dto/request/ProductCreateDto.java
@@ -1,13 +1,16 @@
 package com.fourweekdays.fourweekdays.product.dto.request;
 
-import com.fourweekdays.fourweekdays.category.model.Category;
 import com.fourweekdays.fourweekdays.product.model.Product;
+import com.fourweekdays.fourweekdays.product.model.ProductStatus;
+import com.fourweekdays.fourweekdays.vendor.model.entity.Vendor;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDate;
 
 @Getter
 @Builder
@@ -15,37 +18,33 @@ import java.time.LocalDate;
 @NoArgsConstructor
 public class ProductCreateDto {
 
-    private String productCode;     // SKU/바코드
-    private String productName;     // 상품명
-    private int costPrice;          // 매입가 (원가)
-    private int listPrice;          // 소비자가 (리스트가)
-    private int wholesalePrice;     // 도매가 (가맹점 공급가)
-    private int marginRate;         // 마진율 (%)
-    private String currency;        // 금액 단위 (KRW, USD, JPY 등)
-    private String specification;   // 규격 (예: 500ml, Box 20개입)
-    private LocalDate expirationAt; // 유통기한
-    private String originCountry;   // 원산지
+    @NotBlank(message = "상품명은 필수입니다")
+    @Size(max = 200, message = "상품명은 200자 이하로 입력해주세요")
+    private String name;
 
-    // 카테고리 연관 필드 추가
-    private Long categoryId;        // 기존 카테고리 ID
-    private String categoryLarge;   // 대분류명
-    private String categoryMedium;  // 중분류명
-    private String categorySmall;   // 소분류명
+    @Size(max = 50, message = "단위는 50자 이하로 입력해주세요")
+    private String unit; // EA, Box, Kg 등
+
+    @NotNull(message = "단가는 필수입니다")
+    @Min(value = 0, message = "단가는 0원 이상이어야 합니다")
+    private Long unitPrice;
+
+    @Size(max = 1000, message = "설명은 1000자 이하로 입력해주세요")
+    private String description;
+
+    @NotNull(message = "상품 상태는 필수입니다")
+    private ProductStatus status;
+    private Long vendorId;
 
     // Entity 변환
-    public Product toEntity(Category category) {
+    public Product toEntity(Vendor vendor) {
         return Product.builder()
-                .productCode(this.productCode)
-                .productName(this.productName)
-                .costPrice(this.costPrice)
-                .listPrice(this.listPrice)
-                .wholesalePrice(this.wholesalePrice)
-                .marginRate(this.marginRate)
-                .currency(this.currency)
-                .specification(this.specification)
-                .expirationAt(this.expirationAt != null ? LocalDate.from(this.expirationAt.atStartOfDay()) : null)
-                .originCountry(this.originCountry)
-                .category(category) // 연관관계 주입
+                .name(this.name)
+                .unit(this.unit)
+                .unitPrice(this.unitPrice)
+                .description(this.description)
+                .status(this.status)
+                .vendor(vendor)
                 .build();
     }
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/product/dto/request/ProductCreateDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/product/dto/request/ProductCreateDto.java
@@ -37,14 +37,13 @@ public class ProductCreateDto {
     private Long vendorId;
 
     // Entity 변환
-    public Product toEntity(Vendor vendor) {
+    public Product toEntity() {
         return Product.builder()
                 .name(this.name)
                 .unit(this.unit)
                 .unitPrice(this.unitPrice)
                 .description(this.description)
                 .status(this.status)
-                .vendor(vendor)
                 .build();
     }
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/product/dto/request/ProductUpdateDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/product/dto/request/ProductUpdateDto.java
@@ -31,7 +31,7 @@ public class ProductUpdateDto {
     @NotNull(message = "상품 상태는 필수입니다")
     private ProductStatus status;
 
-//    @NotNull(message = "공급업체는 필수입니다")
-//    private Long vendorId; // 공급업체 변경 가능
+    @NotNull(message = "공급업체는 필수입니다")
+    private Long vendorId; // 공급업체 변경 가능
 }
 

--- a/src/main/java/com/fourweekdays/fourweekdays/product/dto/request/ProductUpdateDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/product/dto/request/ProductUpdateDto.java
@@ -1,0 +1,37 @@
+package com.fourweekdays.fourweekdays.product.dto.request;
+
+
+import com.fourweekdays.fourweekdays.product.model.ProductStatus;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ProductUpdateDto {
+
+    @NotBlank(message = "상품명은 필수입니다")
+    @Size(max = 200, message = "상품명은 200자 이하로 입력해주세요")
+    private String name;
+
+    @Size(max = 50, message = "단위는 50자 이하로 입력해주세요")
+    private String unit;
+
+    @NotNull(message = "단가는 필수입니다")
+    @Min(value = 0, message = "단가는 0원 이상이어야 합니다")
+    private Long unitPrice;
+
+    @Size(max = 1000, message = "설명은 1000자 이하로 입력해주세요")
+    private String description;
+
+    @NotNull(message = "상품 상태는 필수입니다")
+    private ProductStatus status;
+
+//    @NotNull(message = "공급업체는 필수입니다")
+//    private Long vendorId; // 공급업체 변경 가능
+}
+

--- a/src/main/java/com/fourweekdays/fourweekdays/product/dto/response/ProductReadDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/product/dto/response/ProductReadDto.java
@@ -1,42 +1,42 @@
 package com.fourweekdays.fourweekdays.product.dto.response;
 
 import com.fourweekdays.fourweekdays.product.model.Product;
-import lombok.Builder;
-import lombok.Getter;
+import com.fourweekdays.fourweekdays.product.model.ProductStatus;
+import com.fourweekdays.fourweekdays.vendor.model.dto.response.VendorReadDto;
+import lombok.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Builder
 public class ProductReadDto {
 
     private Long id;
     private String productCode;
-    private String productName;
-    private int costPrice;
-    private int listPrice;
-    private int wholesalePrice;
-    private int marginRate;
-    private String currency;
-    private String specification;
-    private LocalDate expirationAt;
-    private String originCountry;
+    private String name;
+    private String unit;
+    private Long unitPrice;
+    private String description;
+    private ProductStatus status;
+    private VendorReadDto vendor; // ← VendorResponse 전체 포함 (C안)
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 
     public static ProductReadDto from(Product product) {
         return ProductReadDto.builder()
                 .id(product.getId())
                 .productCode(product.getProductCode())
-                .productCode(product.getProductCode())
-                .productName(product.getProductName())
-                .costPrice(product.getCostPrice())
-                .listPrice(product.getListPrice())
-                .wholesalePrice(product.getWholesalePrice())
-                .marginRate(product.getMarginRate())
-                .currency(product.getCurrency())
-                .specification(product.getSpecification())
-                .expirationAt(LocalDate.from(product.getExpirationAt()))
-                .originCountry(product.getOriginCountry())
+                .name(product.getName())
+                .unit(product.getUnit())
+                .unitPrice(product.getUnitPrice())
+                .description(product.getDescription())
+                .status(product.getStatus())
+                .vendor(VendorReadDto.from(product.getVendor()))
+                .createdAt(product.getCreatedAt())
+                .updatedAt(product.getUpdatedAt())
                 .build();
     }
-
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/product/exception/ProductException.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/product/exception/ProductException.java
@@ -1,0 +1,11 @@
+package com.fourweekdays.fourweekdays.product.exception;
+
+import com.fourweekdays.fourweekdays.global.exception.BaseException;
+import com.fourweekdays.fourweekdays.global.exception.ExceptionType;
+
+public class ProductException extends BaseException {
+
+    public ProductException(ExceptionType exceptionType) {
+        super(exceptionType);
+    }
+}

--- a/src/main/java/com/fourweekdays/fourweekdays/product/exception/ProductExceptionType.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/product/exception/ProductExceptionType.java
@@ -1,0 +1,29 @@
+package com.fourweekdays.fourweekdays.product.exception;
+
+import com.fourweekdays.fourweekdays.global.exception.ExceptionType;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+public enum ProductExceptionType implements ExceptionType {
+
+    PRODUCT_NOT_FOUND(NOT_FOUND, "상품 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    ProductExceptionType(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus statusCode() {
+        return this.httpStatus;
+    }
+
+    @Override
+    public String message() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/fourweekdays/fourweekdays/product/model/Product.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/product/model/Product.java
@@ -42,5 +42,20 @@ public class Product extends BaseEntity {
 //    private String barcode; // 바코드 추후 구현
 
     // ===== 연관 관계 ===== //
+
+    public void mappingVendor(Vendor vendor) {
+        this.vendor = vendor;
+        vendor.getProductList().add(this);
+    }
+
     // ===== 로직 ===== //
+    public void update(String name, String unit, Long unitPrice,
+                       String description, ProductStatus status, Vendor vendor) {
+        this.name = name;
+        this.unit = unit;
+        this.unitPrice = unitPrice;
+        this.description = description;
+        this.status = status;
+        this.vendor = vendor;
+    }
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/product/service/ProductService.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/product/service/ProductService.java
@@ -1,20 +1,12 @@
 package com.fourweekdays.fourweekdays.product.service;
 
-import com.fourweekdays.fourweekdays.category.model.Category;
-import com.fourweekdays.fourweekdays.category.repository.CategoryRepository;
 import com.fourweekdays.fourweekdays.product.dto.request.ProductCreateDto;
-import com.fourweekdays.fourweekdays.product.dto.request.ProductStatusUpdateDto;
 import com.fourweekdays.fourweekdays.product.dto.request.ProductUpdateDto;
 import com.fourweekdays.fourweekdays.product.dto.response.ProductReadDto;
 import com.fourweekdays.fourweekdays.product.exception.ProductException;
-import com.fourweekdays.fourweekdays.product.exception.ProductExceptionType;
 import com.fourweekdays.fourweekdays.product.model.Product;
-import com.fourweekdays.fourweekdays.product.model.ProductStatus;
-import com.fourweekdays.fourweekdays.product.model.ProductStatusHistory;
 import com.fourweekdays.fourweekdays.product.repository.ProductRepository;
-import com.fourweekdays.fourweekdays.product.repository.ProductStatusHistoryRepository;
 import com.fourweekdays.fourweekdays.vendor.exception.VendorException;
-import com.fourweekdays.fourweekdays.vendor.exception.VendorExceptionType;
 import com.fourweekdays.fourweekdays.vendor.model.entity.Vendor;
 import com.fourweekdays.fourweekdays.vendor.repository.VendorRepository;
 import lombok.RequiredArgsConstructor;
@@ -63,7 +55,7 @@ public class ProductService {
     }
 
     // 상품 수정
-    public void update(Long id, ProductUpdateDto requestDto) {
+    public Long update(Long id, ProductUpdateDto requestDto) {
         Product product = productRepository.findById(id)
                 .orElseThrow(() -> new ProductException(PRODUCT_NOT_FOUND));
 
@@ -74,6 +66,8 @@ public class ProductService {
                 requestDto.getUnitPrice(), requestDto.getDescription(),
                 requestDto.getStatus(), product.getVendor()
         );
+
+        return id;
     }
 
 

--- a/src/main/java/com/fourweekdays/fourweekdays/product/service/ProductService.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/product/service/ProductService.java
@@ -4,12 +4,19 @@ import com.fourweekdays.fourweekdays.category.model.Category;
 import com.fourweekdays.fourweekdays.category.repository.CategoryRepository;
 import com.fourweekdays.fourweekdays.product.dto.request.ProductCreateDto;
 import com.fourweekdays.fourweekdays.product.dto.request.ProductStatusUpdateDto;
+import com.fourweekdays.fourweekdays.product.dto.request.ProductUpdateDto;
 import com.fourweekdays.fourweekdays.product.dto.response.ProductReadDto;
+import com.fourweekdays.fourweekdays.product.exception.ProductException;
+import com.fourweekdays.fourweekdays.product.exception.ProductExceptionType;
 import com.fourweekdays.fourweekdays.product.model.Product;
 import com.fourweekdays.fourweekdays.product.model.ProductStatus;
 import com.fourweekdays.fourweekdays.product.model.ProductStatusHistory;
 import com.fourweekdays.fourweekdays.product.repository.ProductRepository;
 import com.fourweekdays.fourweekdays.product.repository.ProductStatusHistoryRepository;
+import com.fourweekdays.fourweekdays.vendor.exception.VendorException;
+import com.fourweekdays.fourweekdays.vendor.exception.VendorExceptionType;
+import com.fourweekdays.fourweekdays.vendor.model.entity.Vendor;
+import com.fourweekdays.fourweekdays.vendor.repository.VendorRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,70 +24,28 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.fourweekdays.fourweekdays.product.exception.ProductExceptionType.PRODUCT_NOT_FOUND;
+import static com.fourweekdays.fourweekdays.vendor.exception.VendorExceptionType.VENDOR_NOT_FOUND;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ProductService {
 
     private final ProductRepository productRepository;
-    private final CategoryRepository categoryRepository;
-    private final ProductStatusHistoryRepository historyRepository;
+    private final VendorRepository vendorRepository;
+//    private final CategoryRepository categoryRepository;
+//    private final ProductStatusHistoryRepository historyRepository;
 
     // 상품 등록
-    @Transactional
-    public Long register(ProductCreateDto dto) {
-        Category category = null;
+    public Long createProduct(ProductCreateDto requestDto) {
+        Vendor vendor = vendorRepository.findById(requestDto.getVendorId())
+                .orElseThrow(() -> new VendorException(VENDOR_NOT_FOUND));
 
-        // categoryId 존재 시 → 기존 카테고리 연결
-        if (dto.getCategoryId() != null) {
-            category = categoryRepository.findById(dto.getCategoryId())
-                    .orElseThrow(() -> new RuntimeException("해당 카테고리를 찾을 수 없습니다."));
-        }
-
-        // categoryId 없고 이름 정보(categoryLarge~Small)만 있을 경우 → 카테고리 생성 or 조회
-        else if (dto.getCategoryLarge() != null && dto.getCategoryMedium() != null && dto.getCategorySmall() != null) {
-            category = findOrCreateCategory(dto.getCategoryLarge(), dto.getCategoryMedium(), dto.getCategorySmall());
-        }
-
-        // 상품 생성 및 저장
-        Product product = dto.toEntity(category);
-        product.updateStatus(ProductStatus.RECEIVED); // 기본 상태: 입고(RECEIVED)
-        Product saved = productRepository.save(product);
-
-        // 최초 상태 이력 기록
-        ProductStatusHistory history = ProductStatusHistory.builder()
-                .product(saved)
-                .oldStatus(null)
-                .newStatus(ProductStatus.RECEIVED)
-                .changedBy("SYSTEM") // 작업자 ID or 이름 등 정보 필요
-                .build();
-
-        historyRepository.save(history);
-
-        return saved.getId();
-    }
-
-    // 상태 변경(변경시 ProductStatusHistory에 기록)
-    // 상태 전이 규칙 검증
-    @Transactional
-    public ProductStatusHistory updateProductStatus(Long productId, ProductStatusUpdateDto dto) {
-        Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new RuntimeException("상품을 찾을 수 없습니다."));
-
-        ProductStatus oldStatus = product.getStatus();
-        ProductStatus newStatus = dto.getStatus();
-
-        validateStatusTransition(oldStatus, newStatus);
-        product.updateStatus(newStatus);
-
-        ProductStatusHistory history = ProductStatusHistory.builder()
-                .product(product)
-                .oldStatus(oldStatus)
-                .newStatus(newStatus)
-                .changedBy(dto.getChangedBy())
-                .build();
-
-        return historyRepository.save(history);
+        // TODO: 같은 상품이 있는지 판단하는 로직
+        Product product = requestDto.toEntity();
+        product.mappingVendor(vendor); // 연관 관계 매핑 
+        return productRepository.save(product).getId();
     }
 
     // 상품 전체 조회
@@ -97,43 +62,114 @@ public class ProductService {
                 .orElse(null);
     }
 
-    // 상태 전이 검증 로직
-    private void validateStatusTransition(ProductStatus oldStatus, ProductStatus newStatus) {
-        if (oldStatus == ProductStatus.APPROVED) {
-            throw new IllegalStateException("승인된 상품은 더 이상 상태를 변경할 수 없습니다.");
-        }
-        if (oldStatus == ProductStatus.RECEIVED && newStatus != ProductStatus.INSPECTING) {
-            throw new IllegalStateException("입고 상태에서는 검수중으로만 이동할 수 있습니다.");
-        }
-        if (oldStatus == ProductStatus.INSPECTING && newStatus != ProductStatus.INSPECTED) {
-            throw new IllegalStateException("검수중 상태에서는 검수 완료로만 이동할 수 있습니다.");
-        }
-        if (oldStatus == ProductStatus.INSPECTED && newStatus != ProductStatus.STORING) {
-            throw new IllegalStateException("검수 완료 상태에서는 적치중으로만 이동할 수 있습니다.");
-        }
-        if (oldStatus == ProductStatus.STORING && newStatus != ProductStatus.APPROVED) {
-            throw new IllegalStateException("적치중 상태에서는 승인으로만 이동할 수 있습니다.");
-        }
+    // 상품 수정
+    public void update(Long id, ProductUpdateDto requestDto) {
+        Product product = productRepository.findById(id)
+                .orElseThrow(() -> new ProductException(PRODUCT_NOT_FOUND));
+
+        vendorRepository.findById(requestDto.getVendorId())
+                .orElseThrow(() -> new VendorException(VENDOR_NOT_FOUND));
+
+        product.update(requestDto.getName(), requestDto.getUnit(),
+                requestDto.getUnitPrice(), requestDto.getDescription(),
+                requestDto.getStatus(), product.getVendor()
+        );
     }
 
-    // 카테고리 존재하지 않으면 생성
-    private Category findOrCreateCategory(String large, String medium, String small) {
-        Category largeCategory = categoryRepository.findByNameAndParentIsNull(large)
-                .orElseGet(() -> categoryRepository.save(
-                        Category.builder().name(large).active(true).build()
-                ));
 
-        Category mediumCategory = categoryRepository.findByNameAndParent(medium, largeCategory)
-                .orElseGet(() -> categoryRepository.save(
-                        Category.builder().name(medium).parent(largeCategory).active(true).build()
-                ));
+//    @Transactional
+//    public Long register(ProductCreateDto dto) {
+//        Category category = null;
+//
+//        // categoryId 존재 시 → 기존 카테고리 연결
+//        if (dto.getCategoryId() != null) {
+//            category = categoryRepository.findById(dto.getCategoryId())
+//                    .orElseThrow(() -> new RuntimeException("해당 카테고리를 찾을 수 없습니다."));
+//        }
+//
+//        // categoryId 없고 이름 정보(categoryLarge~Small)만 있을 경우 → 카테고리 생성 or 조회
+//        else if (dto.getCategoryLarge() != null && dto.getCategoryMedium() != null && dto.getCategorySmall() != null) {
+//            category = findOrCreateCategory(dto.getCategoryLarge(), dto.getCategoryMedium(), dto.getCategorySmall());
+//        }
+//
+//        // 상품 생성 및 저장
+//        Product product = dto.toEntity(category);
+//        product.updateStatus(ProductStatus.RECEIVED); // 기본 상태: 입고(RECEIVED)
+//        Product saved = productRepository.save(product);
+//
+//        // 최초 상태 이력 기록
+//        ProductStatusHistory history = ProductStatusHistory.builder()
+//                .product(saved)
+//                .oldStatus(null)
+//                .newStatus(ProductStatus.RECEIVED)
+//                .changedBy("SYSTEM") // 작업자 ID or 이름 등 정보 필요
+//                .build();
+//
+//        historyRepository.save(history);
+//
+//        return saved.getId();
+//    }
 
-        Category smallCategory = categoryRepository.findByNameAndParent(small, mediumCategory)
-                .orElseGet(() -> categoryRepository.save(
-                        Category.builder().name(small).parent(mediumCategory).active(true).build()
-                ));
+//    // 상태 변경(변경시 ProductStatusHistory에 기록)
+//    // 상태 전이 규칙 검증
+//    @Transactional
+//    public ProductStatusHistory updateProductStatus(Long productId, ProductStatusUpdateDto dto) {
+//        Product product = productRepository.findById(productId)
+//                .orElseThrow(() -> new RuntimeException("상품을 찾을 수 없습니다."));
+//
+//        ProductStatus oldStatus = product.getStatus();
+//        ProductStatus newStatus = dto.getStatus();
+//
+//        validateStatusTransition(oldStatus, newStatus);
+//        product.updateStatus(newStatus);
+//
+//        ProductStatusHistory history = ProductStatusHistory.builder()
+//                .product(product)
+//                .oldStatus(oldStatus)
+//                .newStatus(newStatus)
+//                .changedBy(dto.getChangedBy())
+//                .build();
+//
+//        return historyRepository.save(history);
+//    }
 
-        return smallCategory;
-    }
+//    // 상태 전이 검증 로직
+//    private void validateStatusTransition(ProductStatus oldStatus, ProductStatus newStatus) {
+//        if (oldStatus == ProductStatus.APPROVED) {
+//            throw new IllegalStateException("승인된 상품은 더 이상 상태를 변경할 수 없습니다.");
+//        }
+//        if (oldStatus == ProductStatus.RECEIVED && newStatus != ProductStatus.INSPECTING) {
+//            throw new IllegalStateException("입고 상태에서는 검수중으로만 이동할 수 있습니다.");
+//        }
+//        if (oldStatus == ProductStatus.INSPECTING && newStatus != ProductStatus.INSPECTED) {
+//            throw new IllegalStateException("검수중 상태에서는 검수 완료로만 이동할 수 있습니다.");
+//        }
+//        if (oldStatus == ProductStatus.INSPECTED && newStatus != ProductStatus.STORING) {
+//            throw new IllegalStateException("검수 완료 상태에서는 적치중으로만 이동할 수 있습니다.");
+//        }
+//        if (oldStatus == ProductStatus.STORING && newStatus != ProductStatus.APPROVED) {
+//            throw new IllegalStateException("적치중 상태에서는 승인으로만 이동할 수 있습니다.");
+//        }
+//    }
+
+//    // 카테고리 존재하지 않으면 생성
+//    private Category findOrCreateCategory(String large, String medium, String small) {
+//        Category largeCategory = categoryRepository.findByNameAndParentIsNull(large)
+//                .orElseGet(() -> categoryRepository.save(
+//                        Category.builder().name(large).active(true).build()
+//                ));
+//
+//        Category mediumCategory = categoryRepository.findByNameAndParent(medium, largeCategory)
+//                .orElseGet(() -> categoryRepository.save(
+//                        Category.builder().name(medium).parent(largeCategory).active(true).build()
+//                ));
+//
+//        Category smallCategory = categoryRepository.findByNameAndParent(small, mediumCategory)
+//                .orElseGet(() -> categoryRepository.save(
+//                        Category.builder().name(small).parent(mediumCategory).active(true).build()
+//                ));
+//
+//        return smallCategory;
+//    }
 
 }


### PR DESCRIPTION
# 🧩 Issue Number
- #85 

## 📝 요약
- 상품 api를 위한 dto를 구현
- 상품 엔티티와 컬럼 변경에 의해 깨진 비즈니스 로직 복구
- 상품 도메인 관련 예외 처리 구조 구현

## 🔍 변경 사항
- 상품 생성/조회/수정에 대한 dto  구현
- 상품 카테고리에 대한 논의 전까지 현재 카테고리 도메인을 사용하지 않으므로 그에 따른 로직 변경
- close #85 

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수 했는가?
- [x] 커밋 내용에 시크릿 키 등의 공유되지 말아야 할 것들을 제거 했는가?

## 💬 기타 공유사항
일단 설님이 구현하신 로직은 주석처리하고 최소한의 기능을 갖게 제가 변경했습니다.
카테고리에 대한 것은 회의 후에 다시 결정하는 것이 좋을 것 같아서 일단 빼고 구현했습니다.
또한, 예외 처리 구조를 추가했으므로 보고 사용하시면 됩니다. 
