### PR TITLE
Refactor: purchaseorder dto for swagger

### DIFF
--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/controller/PurchaseOrderController.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/controller/PurchaseOrderController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@RequestMapping("/api/purchase")
+@RequestMapping("/api/purchase-orders")
 @RequiredArgsConstructor
 @RestController
 public class PurchaseOrderController {

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/request/PurchaseOrderCreateDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/request/PurchaseOrderCreateDto.java
@@ -2,12 +2,15 @@ package com.fourweekdays.fourweekdays.purchaseorder.model.dto.request;
 
 import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrder;
 import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrderStatus;
-import com.fourweekdays.fourweekdays.vendor.Vendor;
+import com.fourweekdays.fourweekdays.vendor.model.entity.Vendor;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -17,21 +20,25 @@ public class PurchaseOrderCreateDto {
     private Long vendorId; // 공급업체 ID
 
     @NotNull(message = "발주일을 입력해주세요")
-    private LocalDate issueDate; // 발주일
+    private LocalDateTime orderDate; // 발주일
 
     @NotNull(message = "입고 예정일을 입력해주세요")
-    private LocalDate expectedDate; // 입고 예정일
+    private LocalDateTime expectedDate; // 입고 예정일
 
-//    @NotEmpty(message = "품목을 최소 1개 이상 추가해주세요")
-//    private List<PurchaseOrderItemDto> items;  // 품목 목록
+    @NotEmpty(message = "발주 상품을 선택해주세요.")
+    private List<PurchaseOrderItemDto> items;
+
+    @Size(max = 1000, message = "비고는 1000자 이내로 입력해주세요")
+    private String description;
 
     // TODO: 다른 엔티티가 정의되면 리팩토링
     public PurchaseOrder toEntity(Vendor vendor) {
         return PurchaseOrder.builder()
                 .vendor(vendor)
                 .status(PurchaseOrderStatus.REQUESTED)
-                .issueDate(this.issueDate)
+                .orderDate(this.orderDate)
                 .expectedDate(this.expectedDate)
+                .description(this.description)
                 .build();
     }
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/request/PurchaseOrderCreateDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/request/PurchaseOrderCreateDto.java
@@ -26,7 +26,7 @@ public class PurchaseOrderCreateDto {
     private LocalDateTime expectedDate; // 입고 예정일
 
     @NotEmpty(message = "발주 상품을 선택해주세요.")
-    private List<PurchaseOrderItemDto> items;
+    private List<PurchaseOrderItemRequestDto> items;
 
     @Size(max = 1000, message = "비고는 1000자 이내로 입력해주세요")
     private String description;

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/request/PurchaseOrderItemDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/request/PurchaseOrderItemDto.java
@@ -1,0 +1,23 @@
+package com.fourweekdays.fourweekdays.purchaseorder.model.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class PurchaseOrderItemDto {
+
+    @NotNull(message = "상품 ID를 입력하세요.")
+    private Long productId;
+
+    @NotNull(message = "발주 수량을 입력하세요.")
+    @Min(value = 1, message = "발주 수량은 1개 이상이어야 합니다")
+    private Integer orderedQuantity;
+
+    @Size(max = 500, message = "비고는 500자 이하로 입력해주세요")
+    private String description;
+}

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/request/PurchaseOrderItemRequestDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/request/PurchaseOrderItemRequestDto.java
@@ -9,7 +9,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class PurchaseOrderItemDto {
+public class PurchaseOrderItemRequestDto {
 
     @NotNull(message = "상품 ID를 입력하세요.")
     private Long productId;

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/response/PurchaseOrderItemResponseDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/response/PurchaseOrderItemResponseDto.java
@@ -1,0 +1,21 @@
+package com.fourweekdays.fourweekdays.purchaseorder.model.dto.response;
+
+import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrderProductItem;
+import lombok.Builder;
+
+@Builder
+public record PurchaseOrderItemResponseDto(
+        Long id,
+        String productName,
+        Integer orderedQuantity,
+        String description
+) {
+    public static PurchaseOrderItemResponseDto toDto(PurchaseOrderProductItem item) {
+        return PurchaseOrderItemResponseDto.builder()
+                .id(item.getId())
+                .productName(item.getProduct().getName())
+                .orderedQuantity(item.getOrderedQuantity())
+                .description(item.getDescription())
+                .build();
+    }
+}

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/response/PurchaseOrderReadDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/response/PurchaseOrderReadDto.java
@@ -4,32 +4,40 @@ import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrder;
 import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrderStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 
+
+@Getter
 @AllArgsConstructor
 @Builder
 public class PurchaseOrderReadDto {
 
     private final Long id;
-
-    private final String vendorName; // TODO: 공급 업체 연관관계 맞춘 후 변경
-
-    //    private final Long quantity; // TODO: 상품 마다 발주 수량이 다른 경우 때문에 상품과 연관 관계 필요
-    private final Long totalAmount; // 발주 금액
-
-    private LocalDate issueDate;
-    private LocalDate expectedDate;
-
-    private PurchaseOrderStatus status;
+    private final String orderNumber; // 발주번호
+    private final String vendorName;
+    private final LocalDateTime orderDate; // 발주일
+    private final LocalDateTime expectedDate; // 입고예정일
+    private final PurchaseOrderStatus status; // 상태
+    private final Long totalAmount; // 총 금액
+    private final String description; // 비고
+    private final List<PurchaseOrderItemResponseDto> items; // 발주 상품 목록
 
     public static PurchaseOrderReadDto toDto(PurchaseOrder entity) {
         return PurchaseOrderReadDto.builder()
                 .id(entity.getId())
-                .totalAmount(entity.getTotalAmount())
-                .issueDate(entity.getIssueDate())
+                .orderNumber(entity.getOrderNumber())
+                .vendorName(entity.getVendor().getName())
+                .orderDate(entity.getOrderDate())
                 .expectedDate(entity.getExpectedDate())
                 .status(entity.getStatus())
+                .totalAmount(entity.getTotalAmount())
+                .description(entity.getDescription())
+                .items(entity.getItems().stream()
+                        .map(PurchaseOrderItemResponseDto::toDto)
+                        .toList())
                 .build();
     }
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/service/PurchaseOrderService.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/service/PurchaseOrderService.java
@@ -4,8 +4,8 @@ import com.fourweekdays.fourweekdays.purchaseorder.model.dto.request.PurchaseOrd
 import com.fourweekdays.fourweekdays.purchaseorder.model.dto.response.PurchaseOrderReadDto;
 import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrder;
 import com.fourweekdays.fourweekdays.purchaseorder.repository.PurchaseOrderRepository;
-import com.fourweekdays.fourweekdays.vendor.Vendor;
-import com.fourweekdays.fourweekdays.vendor.VendorRepository;
+import com.fourweekdays.fourweekdays.vendor.model.entity.Vendor;
+import com.fourweekdays.fourweekdays.vendor.repository.VendorRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;


### PR DESCRIPTION
# 🧩 Issue Number
- #87 

## 📝 요약
- 발주 생성 dto 변경
- 발주 조회 dto 변경

## 🔍 변경 사항
- 발주 생성/조회 dto를 변경
- 발주-상품 연관 관계로 인한 발주 상품(중간 엔티티)에 대한 dto 구현
- close #87 

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수 했는가?
- [x] 커밋 내용에 시크릿 키 등의 공유되지 말아야 할 것들을 제거 했는가?

## 💬 기타 공유사항
- 발주 부분은 특별히 많은 기능은 없고 생성/조회만 존재하는데 더 필요한게 있을까요?
