### PR TITLE
Feat/inbound

### DIFF
--- a/src/main/java/com/fourweekdays/fourweekdays/inbound/exception/InboundExceptionType.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/inbound/exception/InboundExceptionType.java
@@ -19,11 +19,11 @@ public enum InboundExceptionType implements ExceptionType {
 
     @Override
     public HttpStatus statusCode() {
-        return null;
+        return this.httpStatus;
     }
 
     @Override
     public String message() {
-        return "";
+        return this.message;
     }
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/inbound/exception/InboundExceptionType.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/inbound/exception/InboundExceptionType.java
@@ -3,9 +3,11 @@ package com.fourweekdays.fourweekdays.inbound.exception;
 import com.fourweekdays.fourweekdays.global.exception.ExceptionType;
 import org.springframework.http.HttpStatus;
 
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
 public enum InboundExceptionType implements ExceptionType {
-    // 구조만 따라함 아직 사용 x
-    ;
+
+    INBOUND_NOT_FOUND(NOT_FOUND, "해당 발주를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fourweekdays/fourweekdays/inbound/model/dto/request/InboundCreateRequestDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/inbound/model/dto/request/InboundCreateRequestDto.java
@@ -13,8 +13,8 @@ import java.util.List;
 public class InboundCreateRequestDto {
 
     private Long memberId;
-    private Long purchaseOrderId;  // Optional: 발주서 기반 입고
 
+    private Long purchaseOrderId;  // 발주서 기반 입고
     @Valid
     private List<InboundItemDto> items;  // Optional: 직접/추가 품목
 

--- a/src/main/java/com/fourweekdays/fourweekdays/inbound/model/entity/Inbound.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/inbound/model/entity/Inbound.java
@@ -43,7 +43,11 @@ public class Inbound extends BaseEntity {
     private List<InboundProductItem> items = new ArrayList<>();
 
     private String description; // 비고
-    
+
+    public void updatePurchaseOrder(PurchaseOrder purchaseOrder) {
+        this.purchaseOrder = purchaseOrder;
+    }
+
 //    private String invoiceNumber; // 송장 번호
 //    private String receivedBy; // 입고 담당자
 //    private String driverName; // 배달 기사

--- a/src/main/java/com/fourweekdays/fourweekdays/inbound/model/entity/InboundProductItem.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/inbound/model/entity/InboundProductItem.java
@@ -45,7 +45,10 @@ public class InboundProductItem extends BaseEntity {
     private String description; // 비고
 
     // ===== 연관관계 편의 메서드 ===== //
-    // ... Inbound 할당 메서드 ...
+    public void assignInbound(Inbound inbound) {
+        this.inbound = inbound;
+        inbound.getItems().add(this);
+    }
 
     // ===== 비즈니스 로직 ===== //
     // ... 입고 수량 검증 메서드 ...

--- a/src/main/java/com/fourweekdays/fourweekdays/inbound/service/InboundService.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/inbound/service/InboundService.java
@@ -1,5 +1,6 @@
 package com.fourweekdays.fourweekdays.inbound.service;
 
+import com.fourweekdays.fourweekdays.inbound.exception.InboundException;
 import com.fourweekdays.fourweekdays.inbound.model.dto.request.InboundCreateRequestDto;
 import com.fourweekdays.fourweekdays.inbound.model.dto.request.InboundUpdateRequestDto;
 import com.fourweekdays.fourweekdays.inbound.model.dto.response.InboundReadDto;
@@ -8,28 +9,23 @@ import com.fourweekdays.fourweekdays.inbound.model.entity.InboundProductItem;
 import com.fourweekdays.fourweekdays.inbound.model.entity.InboundStatus;
 import com.fourweekdays.fourweekdays.inbound.repository.InboundRepository;
 import com.fourweekdays.fourweekdays.member.exception.MemberException;
-import com.fourweekdays.fourweekdays.member.exception.MemberExceptionType;
 import com.fourweekdays.fourweekdays.member.model.entity.Member;
 import com.fourweekdays.fourweekdays.member.repository.MemberRepository;
 import com.fourweekdays.fourweekdays.product.exception.ProductException;
-import com.fourweekdays.fourweekdays.product.exception.ProductExceptionType;
 import com.fourweekdays.fourweekdays.product.model.Product;
 import com.fourweekdays.fourweekdays.product.repository.ProductRepository;
 import com.fourweekdays.fourweekdays.purchaseorder.exception.PurchaseOrderException;
-import com.fourweekdays.fourweekdays.purchaseorder.exception.PurchaseOrderExceptionType;
 import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrder;
 import com.fourweekdays.fourweekdays.purchaseorder.repository.PurchaseOrderRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
 import java.util.UUID;
 
+import static com.fourweekdays.fourweekdays.inbound.exception.InboundExceptionType.INBOUND_NOT_FOUND;
 import static com.fourweekdays.fourweekdays.member.exception.MemberExceptionType.MEMBER_NOT_FOUND;
 import static com.fourweekdays.fourweekdays.product.exception.ProductExceptionType.PRODUCT_NOT_FOUND;
 import static com.fourweekdays.fourweekdays.purchaseorder.exception.PurchaseOrderExceptionType.PURCHASE_ORDER_NOT_FOUND;
@@ -48,14 +44,17 @@ public class InboundService {
     public Long create(InboundCreateRequestDto requestDto) {
         requestDto.validate();
 
-        // 3. Inbound 엔티티 생성
+        // 1. Inbound Entity
         Inbound inbound = createBaseInbound(requestDto);
 
+        // 2. 발주서를 통한 입고 상품 생성
+        addItemsFromPurchaseOrder(requestDto, inbound);
+
+        // 3. 상품을 통한 입고 상품 생성
+        addDirectItems(requestDto, inbound);
 
         return inboundRepository.save(inbound).getId();
     }
-
-
 
 //    public List<InboundListDto> list(Integer page, Integer size) {
 //        // TODO: dto 변경에 따른 로직 변경
@@ -64,7 +63,8 @@ public class InboundService {
 //    }
 
     public InboundReadDto detail(Long id) {
-        Inbound entity = inboundRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("inbound를 찾을 수 없습니다."));
+        Inbound entity = inboundRepository.findById(id)
+                .orElseThrow(() -> new InboundException(INBOUND_NOT_FOUND));
         return InboundReadDto.from(entity);
     }
 
@@ -80,8 +80,6 @@ public class InboundService {
 //    public void hardDelete(Long id) {
 //        inboundRepository.deleteById(id);
 //    }
-
-
 
     /**
      * TODO: Redis 분산 락을 사용한 순차 번호 생성으로 변경 필요

--- a/src/main/java/com/fourweekdays/fourweekdays/inbound/service/InboundService.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/inbound/service/InboundService.java
@@ -7,45 +7,55 @@ import com.fourweekdays.fourweekdays.inbound.model.entity.Inbound;
 import com.fourweekdays.fourweekdays.inbound.model.entity.InboundProductItem;
 import com.fourweekdays.fourweekdays.inbound.model.entity.InboundStatus;
 import com.fourweekdays.fourweekdays.inbound.repository.InboundRepository;
+import com.fourweekdays.fourweekdays.member.exception.MemberException;
+import com.fourweekdays.fourweekdays.member.exception.MemberExceptionType;
 import com.fourweekdays.fourweekdays.member.model.entity.Member;
 import com.fourweekdays.fourweekdays.member.repository.MemberRepository;
+import com.fourweekdays.fourweekdays.product.exception.ProductException;
+import com.fourweekdays.fourweekdays.product.exception.ProductExceptionType;
+import com.fourweekdays.fourweekdays.product.model.Product;
+import com.fourweekdays.fourweekdays.product.repository.ProductRepository;
+import com.fourweekdays.fourweekdays.purchaseorder.exception.PurchaseOrderException;
+import com.fourweekdays.fourweekdays.purchaseorder.exception.PurchaseOrderExceptionType;
 import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrder;
 import com.fourweekdays.fourweekdays.purchaseorder.repository.PurchaseOrderRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.UUID;
+
+import static com.fourweekdays.fourweekdays.member.exception.MemberExceptionType.MEMBER_NOT_FOUND;
+import static com.fourweekdays.fourweekdays.product.exception.ProductExceptionType.PRODUCT_NOT_FOUND;
+import static com.fourweekdays.fourweekdays.purchaseorder.exception.PurchaseOrderExceptionType.PURCHASE_ORDER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class InboundService {
 
     private final MemberRepository memberRepository;
     private final InboundRepository inboundRepository;
     private final PurchaseOrderRepository purchaseOrderRepository;
+    private final ProductRepository productRepository;
 
-    public Long create(InboundCreateRequestDto dto) {
-        Member manager = memberRepository.findById(dto.getMemberId())
-                .orElseThrow(() -> new IllegalArgumentException("해당 직원을 찾을 수 없습니다."));
+    @Transactional
+    public Long create(InboundCreateRequestDto requestDto) {
+        requestDto.validate();
 
-        PurchaseOrder purchaseOrder = purchaseOrderRepository.findById(dto.getPurchaseOrderId())
-                .orElseThrow(() -> new IllegalArgumentException("해당 발주서를 찾을 수 없습니다."));
+        // 3. Inbound 엔티티 생성
+        Inbound inbound = createBaseInbound(requestDto);
 
-        Inbound inbound = Inbound.builder()
-                .scheduledDate(dto.getScheduledDate())
-                .status(InboundStatus.SCHEDULED)
-                .inboundNumber(generateInboundNumber())
-                .description(dto.getDescription())
-                .purchaseOrder(purchaseOrder)
-                .managerName(manager.getName())
-                .items(null)
-                .build();
+
         return inboundRepository.save(inbound).getId();
     }
+
+
 
 //    public List<InboundListDto> list(Integer page, Integer size) {
 //        // TODO: dto 변경에 따른 로직 변경
@@ -72,9 +82,79 @@ public class InboundService {
 //    }
 
 
+
+    /**
+     * TODO: Redis 분산 락을 사용한 순차 번호 생성으로 변경 필요
+     * 현재는 임시로 UUID 기반 난수 사용 (동시성 이슈 없으나 가독성 낮음)
+     *  1. Redis 분산 락 + 날짜 시퀀스
+     *  2. DB 시퀀스 테이블 + 비관적 락
+     *  3. MariaDB SEQUENCE 객체 활용
+     */
     private String generateInboundNumber() {
-        // TODO: 실제 구현 필요
-        // IB-20251016-001 형식으로 생성
-        return "IB-" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd")) + "-001";
+        String datePrefix = LocalDateTime.now()
+                .format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+        String randomSuffix = UUID.randomUUID()
+                .toString()
+                .replace("-", "")
+                .substring(0, 6)
+                .toUpperCase();
+
+        return String.format("IB-%s-%s", datePrefix, randomSuffix); // 예: IB-20251016-A7F3B2
+    }
+
+    private Inbound createBaseInbound(InboundCreateRequestDto requestDto) {
+        Member manager = memberRepository.findById(requestDto.getMemberId())
+                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+
+        return Inbound.builder()
+                .inboundNumber(generateInboundNumber())
+                .status(InboundStatus.SCHEDULED)
+                .managerName(manager.getName())
+                .scheduledDate(requestDto.getScheduledDate())
+                .description(requestDto.getDescription())
+                .build();
+    }
+
+    private void addItemsFromPurchaseOrder(InboundCreateRequestDto requestDto, Inbound inbound) {
+        if (requestDto.getPurchaseOrderId() == null) {
+            return;
+        }
+
+        PurchaseOrder purchaseOrder = purchaseOrderRepository.findById(requestDto.getPurchaseOrderId())
+                .orElseThrow(() -> new PurchaseOrderException(PURCHASE_ORDER_NOT_FOUND));
+
+        inbound.updatePurchaseOrder(purchaseOrder);
+
+        purchaseOrder.getItems().forEach(poItem -> {
+            InboundProductItem inboundItem = InboundProductItem.builder()
+                    .product(poItem.getProduct())
+                    .purchaseOrderProductItem(poItem)
+                    .receivedQuantity(0)
+                    .description(poItem.getDescription())
+                    .build();
+
+            inboundItem.assignInbound(inbound);
+        });
+    }
+
+    private void addDirectItems(InboundCreateRequestDto requestDto, Inbound inbound) {
+        if (requestDto.getItems() == null || requestDto.getItems().isEmpty()) {
+            return;
+        }
+
+        requestDto.getItems().forEach(itemDto -> {
+            Product product = productRepository.findById(itemDto.getProductId())
+                    .orElseThrow(() -> new ProductException(PRODUCT_NOT_FOUND));
+
+            InboundProductItem inboundItem = InboundProductItem.builder()
+                    .product(product)
+                    .purchaseOrderProductItem(null)
+                    .receivedQuantity(itemDto.getQuantity())
+                    .description(itemDto.getDescription())
+                    .build();
+
+            inboundItem.assignInbound(inbound);
+        });
     }
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/member/exception/MemberException.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/member/exception/MemberException.java
@@ -1,0 +1,11 @@
+package com.fourweekdays.fourweekdays.member.exception;
+
+import com.fourweekdays.fourweekdays.global.exception.BaseException;
+import com.fourweekdays.fourweekdays.global.exception.ExceptionType;
+
+public class MemberException extends BaseException {
+
+    public MemberException(ExceptionType exceptionType) {
+        super(exceptionType);
+    }
+}

--- a/src/main/java/com/fourweekdays/fourweekdays/member/exception/MemberExceptionType.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/member/exception/MemberExceptionType.java
@@ -1,0 +1,30 @@
+package com.fourweekdays.fourweekdays.member.exception;
+
+import com.fourweekdays.fourweekdays.global.exception.ExceptionType;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+public enum MemberExceptionType implements ExceptionType {
+
+    MEMBER_NOT_FOUND(NOT_FOUND, "해당 직원을 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    MemberExceptionType(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus statusCode() {
+        return this.httpStatus;
+    }
+
+    @Override
+    public String message() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/fourweekdays/fourweekdays/product/dto/response/ProductStatusResponseDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/product/dto/response/ProductStatusResponseDto.java
@@ -23,7 +23,7 @@ public class ProductStatusResponseDto {
     public static ProductStatusResponseDto from(ProductStatusHistory history) {
         return ProductStatusResponseDto.builder()
                 .productId(history.getProduct().getId())
-                .productName(history.getProduct().getProductName())
+                .productName(history.getProduct().getName())
                 .oldStatus(history.getOldStatus() != null ? history.getOldStatus().name() : null)
                 .newStatus(history.getNewStatus().name())
                 .changedBy(history.getChangedBy())

--- a/src/main/java/com/fourweekdays/fourweekdays/product/model/Product.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/product/model/Product.java
@@ -23,10 +23,8 @@ public class Product extends BaseEntity {
 
     @Column(nullable = false, length = 200)
     private String name;
-
     @Column(nullable = false, unique = true, length = 50)
     private String productCode;
-    private String productName;
 
     @Column(length = 50)
     private String unit; // 단위 (예: EA, Box ...)

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/exception/PurchaseOrderException.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/exception/PurchaseOrderException.java
@@ -1,0 +1,11 @@
+package com.fourweekdays.fourweekdays.purchaseorder.exception;
+
+import com.fourweekdays.fourweekdays.global.exception.BaseException;
+import com.fourweekdays.fourweekdays.global.exception.ExceptionType;
+
+public class PurchaseOrderException extends BaseException {
+
+    public PurchaseOrderException(ExceptionType exceptionType) {
+        super(exceptionType);
+    }
+}

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/exception/PurchaseOrderExceptionType.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/exception/PurchaseOrderExceptionType.java
@@ -1,0 +1,29 @@
+package com.fourweekdays.fourweekdays.purchaseorder.exception;
+
+import com.fourweekdays.fourweekdays.global.exception.ExceptionType;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+public enum PurchaseOrderExceptionType implements ExceptionType {
+
+    PURCHASE_ORDER_NOT_FOUND(NOT_FOUND, "해당 발주서를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    PurchaseOrderExceptionType(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus statusCode() {
+        return this.httpStatus;
+    }
+
+    @Override
+    public String message() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/fourweekdays/fourweekdays/vendor/controller/VendorController.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/vendor/controller/VendorController.java
@@ -17,7 +17,7 @@ import java.util.List;
 public class VendorController {
     private final VendorService vendorService;
 
-    @GetMapping
+    @PostMapping
     public ResponseEntity<BaseResponse<Long>> createVendor(VendorCreateDto dto) {
         Long result = vendorService.create(dto);
         return ResponseEntity.ok(BaseResponse.success(result));


### PR DESCRIPTION
# 🧩 Issue Number
- #26 

## 📝 요약
- 입고 요청 기능을 구현한다. 

## 🔍 변경 사항
- 연관 관계에 따른 입고 요청 생성 로직 생성
- 입고 예외 처리 구조 추가
- 직원 관련 예외 처리 구조 추가
- 상품(Product)의 productName과 name이 중복되는 문제 제거 - name만 살림
- 공급 업체(Vendor) Controller의 생성 요청이 GetMapping -> PostMapping 으로 변경 
- close #26 

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수 했는가?
- [x] 커밋 내용에 시크릿 키 등의 공유되지 말아야 할 것들을 제거 했는가?

## 💬 기타 공유사항
1. 발주, 입고, 출고 번호 등 PK 이외의 식별자가 필요한 경우 동시성 이슈 해결을 위해 Redis 도입을 생각해 봐야 할 것 같습니다. 
```Java

    /**
     * TODO: Redis 분산 락을 사용한 순차 번호 생성으로 변경 필요
     * 현재는 임시로 UUID 기반 난수 사용 (동시성 이슈 없으나 가독성 낮음)
     *  1. Redis 분산 락 + 날짜 시퀀스
     *  2. DB 시퀀스 테이블 + 비관적 락
     *  3. MariaDB SEQUENCE 객체 활용
     */
    private String generateInboundNumber() {
       // .... 구현 로직 - 현재는 난수 발생으로 가구현 상태 ... //
```

2. 앞으로 필요한 기본 데이터 Vendor, Product, Member 정도에 대해 더미 데이터 필요성이 있어서 작업하겠습니다. 