### PR TITLE
Feat: purchase order

### DIFF
--- a/src/main/java/com/fourweekdays/fourweekdays/config/InitialDataSetup.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/config/InitialDataSetup.java
@@ -13,7 +13,7 @@ import com.fourweekdays.fourweekdays.product.model.entity.Product;
 import com.fourweekdays.fourweekdays.product.model.entity.ProductStatus;
 import com.fourweekdays.fourweekdays.product.repository.ProductRepository;
 import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrder;
-import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrderProductItem;
+import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrderProduct;
 import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrderStatus;
 import com.fourweekdays.fourweekdays.purchaseorder.repository.PurchaseOrderRepository;
 import com.fourweekdays.fourweekdays.vendor.model.entity.Vendor;
@@ -452,28 +452,28 @@ public class InitialDataSetup {
                     .items(new ArrayList<>())
                     .build();
 
-            PurchaseOrderProductItem po1Item1 = PurchaseOrderProductItem.builder()
+            PurchaseOrderProduct po1Item1 = PurchaseOrderProduct.builder()
                     .purchaseOrder(po1)
                     .product(product1)  // 설화수 크림
                     .orderedQuantity(5)
                     .description("VIP 고객용")
                     .build();
 
-            PurchaseOrderProductItem po1Item2 = PurchaseOrderProductItem.builder()
+            PurchaseOrderProduct po1Item2 = PurchaseOrderProduct.builder()
                     .purchaseOrder(po1)
                     .product(product2)  // 라네즈 세럼
                     .orderedQuantity(20)
                     .description("베스트셀러 재고 보충")
                     .build();
 
-            PurchaseOrderProductItem po1Item3 = PurchaseOrderProductItem.builder()
+            PurchaseOrderProduct po1Item3 = PurchaseOrderProduct.builder()
                     .purchaseOrder(po1)
                     .product(product3)  // 헤라 립스틱
                     .orderedQuantity(30)
                     .description("시즌 신제품")
                     .build();
 
-            PurchaseOrderProductItem po1Item4 = PurchaseOrderProductItem.builder()
+            PurchaseOrderProduct po1Item4 = PurchaseOrderProduct.builder()
                     .purchaseOrder(po1)
                     .product(product4)  // 이니스프리 토너
                     .orderedQuantity(50)
@@ -498,21 +498,21 @@ public class InitialDataSetup {
                     .items(new ArrayList<>())
                     .build();
 
-            PurchaseOrderProductItem po2Item1 = PurchaseOrderProductItem.builder()
+            PurchaseOrderProduct po2Item1 = PurchaseOrderProduct.builder()
                     .purchaseOrder(po2)
                     .product(product5)  // 클렌징 폼
                     .orderedQuantity(100)
                     .description("기초 클렌징")
                     .build();
 
-            PurchaseOrderProductItem po2Item2 = PurchaseOrderProductItem.builder()
+            PurchaseOrderProduct po2Item2 = PurchaseOrderProduct.builder()
                     .purchaseOrder(po2)
                     .product(product6)  // 빌리프 아쿠아밤
                     .orderedQuantity(30)
                     .description("프리미엄 라인")
                     .build();
 
-            PurchaseOrderProductItem po2Item3 = PurchaseOrderProductItem.builder()
+            PurchaseOrderProduct po2Item3 = PurchaseOrderProduct.builder()
                     .purchaseOrder(po2)
                     .product(product7)  // 숨 에센스
                     .orderedQuantity(20)
@@ -536,14 +536,14 @@ public class InitialDataSetup {
                     .items(new ArrayList<>())
                     .build();
 
-            PurchaseOrderProductItem po3Item1 = PurchaseOrderProductItem.builder()
+            PurchaseOrderProduct po3Item1 = PurchaseOrderProduct.builder()
                     .purchaseOrder(po3)
                     .product(product9)  // 비타민C 세럼
                     .orderedQuantity(40)
                     .description("인기 기능성")
                     .build();
 
-            PurchaseOrderProductItem po3Item2 = PurchaseOrderProductItem.builder()
+            PurchaseOrderProduct po3Item2 = PurchaseOrderProduct.builder()
                     .purchaseOrder(po3)
                     .product(product10)  // 레티놀 크림
                     .orderedQuantity(25)
@@ -566,21 +566,21 @@ public class InitialDataSetup {
                     .items(new ArrayList<>())
                     .build();
 
-            PurchaseOrderProductItem po4Item1 = PurchaseOrderProductItem.builder()
+            PurchaseOrderProduct po4Item1 = PurchaseOrderProduct.builder()
                     .purchaseOrder(po4)
                     .product(product12)  // 쿠션
                     .orderedQuantity(80)
                     .description("베스트 쿠션")
                     .build();
 
-            PurchaseOrderProductItem po4Item2 = PurchaseOrderProductItem.builder()
+            PurchaseOrderProduct po4Item2 = PurchaseOrderProduct.builder()
                     .purchaseOrder(po4)
                     .product(product13)  // 비비크림
                     .orderedQuantity(60)
                     .description("스테디셀러")
                     .build();
 
-            PurchaseOrderProductItem po4Item3 = PurchaseOrderProductItem.builder()
+            PurchaseOrderProduct po4Item3 = PurchaseOrderProduct.builder()
                     .purchaseOrder(po4)
                     .product(product14)  // 에센스
                     .orderedQuantity(15)
@@ -604,21 +604,21 @@ public class InitialDataSetup {
                     .items(new ArrayList<>())
                     .build();
 
-            PurchaseOrderProductItem po5Item1 = PurchaseOrderProductItem.builder()
+            PurchaseOrderProduct po5Item1 = PurchaseOrderProduct.builder()
                     .purchaseOrder(po5)
                     .product(product15)  // 블러셔
                     .orderedQuantity(50)
                     .description("봄 시즌 색조")
                     .build();
 
-            PurchaseOrderProductItem po5Item2 = PurchaseOrderProductItem.builder()
+            PurchaseOrderProduct po5Item2 = PurchaseOrderProduct.builder()
                     .purchaseOrder(po5)
                     .product(product16)  // 립틴트
                     .orderedQuantity(70)
                     .description("인기 틴트")
                     .build();
 
-            PurchaseOrderProductItem po5Item3 = PurchaseOrderProductItem.builder()
+            PurchaseOrderProduct po5Item3 = PurchaseOrderProduct.builder()
                     .purchaseOrder(po5)
                     .product(product17)  // 마스카라
                     .orderedQuantity(45)
@@ -648,7 +648,7 @@ public class InitialDataSetup {
             InboundProductItem inbound1Item1 = InboundProductItem.builder()
                     .inbound(inbound1)
                     .product(product1)
-                    .purchaseOrderProductItem(po1Item1)
+                    .purchaseOrderProduct(po1Item1)
                     .receivedQuantity(5)
                     .lotNumber("LOT-2025-APF-001")
                     .locationCode("A-01-01")
@@ -658,7 +658,7 @@ public class InitialDataSetup {
             InboundProductItem inbound1Item2 = InboundProductItem.builder()
                     .inbound(inbound1)
                     .product(product2)
-                    .purchaseOrderProductItem(po1Item2)
+                    .purchaseOrderProduct(po1Item2)
                     .receivedQuantity(20)
                     .lotNumber("LOT-2025-APF-002")
                     .locationCode("A-01-02")
@@ -668,7 +668,7 @@ public class InitialDataSetup {
             InboundProductItem inbound1Item3 = InboundProductItem.builder()
                     .inbound(inbound1)
                     .product(product3)
-                    .purchaseOrderProductItem(po1Item3)
+                    .purchaseOrderProduct(po1Item3)
                     .receivedQuantity(30)
                     .lotNumber("LOT-2025-APF-003")
                     .locationCode("A-02-01")
@@ -678,7 +678,7 @@ public class InitialDataSetup {
             InboundProductItem inbound1Item4 = InboundProductItem.builder()
                     .inbound(inbound1)
                     .product(product4)
-                    .purchaseOrderProductItem(po1Item4)
+                    .purchaseOrderProduct(po1Item4)
                     .receivedQuantity(50)
                     .lotNumber("LOT-2025-APF-004")
                     .locationCode("A-01-03")
@@ -706,7 +706,7 @@ public class InitialDataSetup {
             InboundProductItem inbound2Item1 = InboundProductItem.builder()
                     .inbound(inbound2)
                     .product(product9)
-                    .purchaseOrderProductItem(po3Item1)
+                    .purchaseOrderProduct(po3Item1)
                     .receivedQuantity(40)
                     .lotNumber("LOT-2025-CSM-001")
                     .locationCode("B-01-01")
@@ -716,7 +716,7 @@ public class InitialDataSetup {
             InboundProductItem inbound2Item2 = InboundProductItem.builder()
                     .inbound(inbound2)
                     .product(product10)
-                    .purchaseOrderProductItem(po3Item2)
+                    .purchaseOrderProduct(po3Item2)
                     .receivedQuantity(25)
                     .lotNumber("LOT-2025-CSM-002")
                     .locationCode("B-01-02")

--- a/src/main/java/com/fourweekdays/fourweekdays/config/InitialDataSetup.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/config/InitialDataSetup.java
@@ -447,7 +447,6 @@ public class InitialDataSetup {
                     .orderDate(LocalDateTime.now().minusDays(15))
                     .expectedDate(LocalDateTime.now().plusDays(3))
                     .status(PurchaseOrderStatus.APPROVED)
-                    .totalAmount(2740000L)
                     .description("설화수, 라네즈 정기 발주")
                     .items(new ArrayList<>())
                     .build();
@@ -493,7 +492,6 @@ public class InitialDataSetup {
                     .orderDate(LocalDateTime.now().minusDays(10))
                     .expectedDate(LocalDateTime.now().plusDays(7))
                     .status(PurchaseOrderStatus.REQUESTED)
-                    .totalAmount(2370000L)
                     .description("더페이스샵, 빌리프 신규 입고")
                     .items(new ArrayList<>())
                     .build();
@@ -531,7 +529,6 @@ public class InitialDataSetup {
                     .orderDate(LocalDateTime.now().minusDays(8))
                     .expectedDate(LocalDateTime.now().plusDays(10))
                     .status(PurchaseOrderStatus.APPROVED)
-                    .totalAmount(1530000L)
                     .description("기능성 화장품 긴급 발주")
                     .items(new ArrayList<>())
                     .build();
@@ -561,7 +558,6 @@ public class InitialDataSetup {
                     .orderDate(LocalDateTime.now().minusDays(5))
                     .expectedDate(LocalDateTime.now().plusDays(5))
                     .status(PurchaseOrderStatus.APPROVED)
-                    .totalAmount(1913000L)
                     .description("미샤 인기 제품 재입고")
                     .items(new ArrayList<>())
                     .build();
@@ -599,7 +595,6 @@ public class InitialDataSetup {
                     .orderDate(LocalDateTime.now().minusDays(3))
                     .expectedDate(LocalDateTime.now().plusDays(12))
                     .status(PurchaseOrderStatus.REQUESTED)
-                    .totalAmount(1647000L)
                     .description("색조 화장품 대량 발주")
                     .items(new ArrayList<>())
                     .build();

--- a/src/main/java/com/fourweekdays/fourweekdays/config/InitialDataSetup.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/config/InitialDataSetup.java
@@ -213,7 +213,7 @@ public class InitialDataSetup {
             // 3. 상품 (화장품)
             // 아모레퍼시픽 제품들
             Product product1 = Product.builder()
-                    .productCode("P-001")
+                    .productCode("PRD-001")
                     .name("설화수 자음생 크림")
                     .unit("EA")
                     .unitPrice(380000L)
@@ -224,7 +224,7 @@ public class InitialDataSetup {
             productRepository.save(product1);
 
             Product product2 = Product.builder()
-                    .productCode("P-002")
+                    .productCode("PRD-002")
                     .name("라네즈 워터뱅크 세럼")
                     .unit("EA")
                     .unitPrice(32000L)
@@ -235,7 +235,7 @@ public class InitialDataSetup {
             productRepository.save(product2);
 
             Product product3 = Product.builder()
-                    .productCode("P-003")
+                    .productCode("PRD-003")
                     .name("헤라 센슈얼 누드 립스틱")
                     .unit("EA")
                     .unitPrice(28000L)
@@ -246,7 +246,7 @@ public class InitialDataSetup {
             productRepository.save(product3);
 
             Product product4 = Product.builder()
-                    .productCode("P-004")
+                    .productCode("PRD-004")
                     .name("이니스프리 그린티 토너")
                     .unit("EA")
                     .unitPrice(15000L)
@@ -258,7 +258,7 @@ public class InitialDataSetup {
 
             // LG생활건강 제품들
             Product product5 = Product.builder()
-                    .productCode("P-005")
+                    .productCode("PRD-005")
                     .name("더페이스샵 클렌징 폼")
                     .unit("EA")
                     .unitPrice(8000L)
@@ -269,7 +269,7 @@ public class InitialDataSetup {
             productRepository.save(product5);
 
             Product product6 = Product.builder()
-                    .productCode("P-006")
+                    .productCode("PRD-006")
                     .name("빌리프 아쿠아밤")
                     .unit("EA")
                     .unitPrice(38000L)
@@ -280,7 +280,7 @@ public class InitialDataSetup {
             productRepository.save(product6);
 
             Product product7 = Product.builder()
-                    .productCode("P-007")
+                    .productCode("PRD-007")
                     .name("숨 시크릿 에센스")
                     .unit("EA")
                     .unitPrice(45000L)
@@ -291,7 +291,7 @@ public class InitialDataSetup {
             productRepository.save(product7);
 
             Product product8 = Product.builder()
-                    .productCode("P-008")
+                    .productCode("PRD-008")
                     .name("오휘 프라임 어드바이저")
                     .unit("EA")
                     .unitPrice(65000L)
@@ -303,7 +303,7 @@ public class InitialDataSetup {
 
             // 코스맥스 제품들
             Product product9 = Product.builder()
-                    .productCode("P-009")
+                    .productCode("PRD-009")
                     .name("비타민C 세럼")
                     .unit("EA")
                     .unitPrice(25000L)
@@ -314,7 +314,7 @@ public class InitialDataSetup {
             productRepository.save(product9);
 
             Product product10 = Product.builder()
-                    .productCode("P-010")
+                    .productCode("PRD-010")
                     .name("레티놀 크림")
                     .unit("EA")
                     .unitPrice(35000L)
@@ -325,7 +325,7 @@ public class InitialDataSetup {
             productRepository.save(product10);
 
             Product product11 = Product.builder()
-                    .productCode("P-011")
+                    .productCode("PRD-011")
                     .name("히알루론산 토너")
                     .unit("EA")
                     .unitPrice(18000L)
@@ -337,7 +337,7 @@ public class InitialDataSetup {
 
             // 에이블씨엔씨 제품들
             Product product12 = Product.builder()
-                    .productCode("P-012")
+                    .productCode("PRD-012")
                     .name("미샤 쿠션 파운데이션")
                     .unit("EA")
                     .unitPrice(14000L)
@@ -348,7 +348,7 @@ public class InitialDataSetup {
             productRepository.save(product12);
 
             Product product13 = Product.builder()
-                    .productCode("P-013")
+                    .productCode("PRD-013")
                     .name("미샤 퍼펙트 커버 비비크림")
                     .unit("EA")
                     .unitPrice(9800L)
@@ -359,7 +359,7 @@ public class InitialDataSetup {
             productRepository.save(product13);
 
             Product product14 = Product.builder()
-                    .productCode("P-014")
+                    .productCode("PRD-014")
                     .name("미샤 타임 레볼루션 에센스")
                     .unit("EA")
                     .unitPrice(35000L)
@@ -371,7 +371,7 @@ public class InitialDataSetup {
 
             // 토니모리 제품들
             Product product15 = Product.builder()
-                    .productCode("P-015")
+                    .productCode("PRD-015")
                     .name("토니모리 치크 블러셔")
                     .unit("EA")
                     .unitPrice(12000L)
@@ -382,7 +382,7 @@ public class InitialDataSetup {
             productRepository.save(product15);
 
             Product product16 = Product.builder()
-                    .productCode("P-016")
+                    .productCode("PRD-016")
                     .name("토니모리 립틴트")
                     .unit("EA")
                     .unitPrice(9900L)
@@ -393,7 +393,7 @@ public class InitialDataSetup {
             productRepository.save(product16);
 
             Product product17 = Product.builder()
-                    .productCode("P-017")
+                    .productCode("PRD-017")
                     .name("토니모리 마스카라")
                     .unit("EA")
                     .unitPrice(15000L)
@@ -405,7 +405,7 @@ public class InitialDataSetup {
 
             // 네이처리퍼블릭 제품들
             Product product18 = Product.builder()
-                    .productCode("P-018")
+                    .productCode("PRD-018")
                     .name("알로에 수딩젤")
                     .unit("EA")
                     .unitPrice(7900L)
@@ -416,7 +416,7 @@ public class InitialDataSetup {
             productRepository.save(product18);
 
             Product product19 = Product.builder()
-                    .productCode("P-019")
+                    .productCode("PRD-019")
                     .name("아르간 에센셜 오일")
                     .unit("EA")
                     .unitPrice(25000L)
@@ -427,7 +427,7 @@ public class InitialDataSetup {
             productRepository.save(product19);
 
             Product product20 = Product.builder()
-                    .productCode("P-020")
+                    .productCode("PRD-020")
                     .name("시카 크림")
                     .unit("EA")
                     .unitPrice(22000L)
@@ -442,7 +442,7 @@ public class InitialDataSetup {
             // 4. 발주
             // 발주 1: 아모레퍼시픽 제품 대량 발주
             PurchaseOrder po1 = PurchaseOrder.builder()
-                    .orderNumber("PO-20250415-001")
+                    .orderCode("PO-20250415-001")
                     .vendor(vendor1)
                     .orderDate(LocalDateTime.now().minusDays(15))
                     .expectedDate(LocalDateTime.now().plusDays(3))
@@ -488,7 +488,7 @@ public class InitialDataSetup {
 
             // 발주 2: LG생활건강 제품 발주
             PurchaseOrder po2 = PurchaseOrder.builder()
-                    .orderNumber("PO-20250416-001")
+                    .orderCode("PO-20250416-001")
                     .vendor(vendor2)
                     .orderDate(LocalDateTime.now().minusDays(10))
                     .expectedDate(LocalDateTime.now().plusDays(7))
@@ -526,7 +526,7 @@ public class InitialDataSetup {
 
             // 발주 3: 코스맥스 ODM 제품 발주
             PurchaseOrder po3 = PurchaseOrder.builder()
-                    .orderNumber("PO-20250417-001")
+                    .orderCode("PO-20250417-001")
                     .vendor(vendor3)
                     .orderDate(LocalDateTime.now().minusDays(8))
                     .expectedDate(LocalDateTime.now().plusDays(10))
@@ -556,7 +556,7 @@ public class InitialDataSetup {
 
             // 발주 4: 미샤 제품 발주
             PurchaseOrder po4 = PurchaseOrder.builder()
-                    .orderNumber("PO-20250418-001")
+                    .orderCode("PO-20250418-001")
                     .vendor(vendor4)
                     .orderDate(LocalDateTime.now().minusDays(5))
                     .expectedDate(LocalDateTime.now().plusDays(5))
@@ -594,7 +594,7 @@ public class InitialDataSetup {
 
             // 발주 5: 토니모리 색조 제품 발주
             PurchaseOrder po5 = PurchaseOrder.builder()
-                    .orderNumber("PO-20250419-001")
+                    .orderCode("PO-20250419-001")
                     .vendor(vendor5)
                     .orderDate(LocalDateTime.now().minusDays(3))
                     .expectedDate(LocalDateTime.now().plusDays(12))

--- a/src/main/java/com/fourweekdays/fourweekdays/inbound/model/dto/response/InboundProductItemResponseDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/inbound/model/dto/response/InboundProductItemResponseDto.java
@@ -40,12 +40,12 @@ public class InboundProductItemResponseDto {
                 .description(item.getDescription())
 
                 .purchaseOrderProductItemId(
-                        item.getPurchaseOrderProductItem() != null ?
-                                item.getPurchaseOrderProductItem().getId() : null)
+                        item.getPurchaseOrderProduct() != null ?
+                                item.getPurchaseOrderProduct().getId() : null)
                 .orderedQuantity(
-                        item.getPurchaseOrderProductItem() != null ?
-                                item.getPurchaseOrderProductItem().getOrderedQuantity() : null)
-                .isFromPurchaseOrder(item.getPurchaseOrderProductItem() != null)
+                        item.getPurchaseOrderProduct() != null ?
+                                item.getPurchaseOrderProduct().getOrderedQuantity() : null)
+                .isFromPurchaseOrder(item.getPurchaseOrderProduct() != null)
                 .build();
     }
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/inbound/model/dto/response/InboundReadDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/inbound/model/dto/response/InboundReadDto.java
@@ -56,7 +56,7 @@ public class InboundReadDto {
                 .purchaseOrder(inbound.getPurchaseOrder() != null ?
                         PurchaseOrderSummary.builder()
                                 .id(inbound.getPurchaseOrder().getId())
-                                .orderNumber(inbound.getPurchaseOrder().getOrderNumber())
+                                .orderNumber(inbound.getPurchaseOrder().getOrderCode())
                                 .vendorName(inbound.getPurchaseOrder().getVendor().getName())
                                 .orderDate(inbound.getPurchaseOrder().getOrderDate())
                                 .build()

--- a/src/main/java/com/fourweekdays/fourweekdays/inbound/model/entity/InboundProductItem.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/inbound/model/entity/InboundProductItem.java
@@ -3,7 +3,7 @@ package com.fourweekdays.fourweekdays.inbound.model.entity;
 
 import com.fourweekdays.fourweekdays.common.BaseEntity;
 import com.fourweekdays.fourweekdays.product.model.entity.Product;
-import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrderProductItem;
+import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrderProduct;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -27,7 +27,7 @@ public class InboundProductItem extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "purchase_order_product_item_id")
-    private PurchaseOrderProductItem purchaseOrderProductItem;
+    private PurchaseOrderProduct purchaseOrderProduct;
 
     @Column(nullable = false)
     private Integer receivedQuantity; // 입고 수량
@@ -43,10 +43,10 @@ public class InboundProductItem extends BaseEntity {
     private String description; // 비고
 
     @Builder
-    public InboundProductItem(Long id, Inbound inbound, Product product, PurchaseOrderProductItem purchaseOrderProductItem, Integer receivedQuantity, String lotNumber, String locationCode, String description) {
+    public InboundProductItem(Long id, Inbound inbound, Product product, PurchaseOrderProduct purchaseOrderProduct, Integer receivedQuantity, String lotNumber, String locationCode, String description) {
         assignInbound(inbound);
         this.product = product;
-        this.purchaseOrderProductItem = purchaseOrderProductItem;
+        this.purchaseOrderProduct = purchaseOrderProduct;
         this.receivedQuantity = receivedQuantity;
         this.lotNumber = lotNumber;
         this.locationCode = locationCode;

--- a/src/main/java/com/fourweekdays/fourweekdays/inbound/service/InboundService.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/inbound/service/InboundService.java
@@ -129,7 +129,7 @@ public class InboundService {
         purchaseOrder.getItems().forEach(poItem -> {
             InboundProductItem inboundItem = InboundProductItem.builder()
                     .product(poItem.getProduct())
-                    .purchaseOrderProductItem(poItem)
+                    .purchaseOrderProduct(poItem)
                     .receivedQuantity(0)
                     .description(poItem.getDescription())
                     .build();
@@ -150,7 +150,7 @@ public class InboundService {
             InboundProductItem inboundItem = InboundProductItem.builder()
                     .product(product)
                     .inbound(inbound)
-                    .purchaseOrderProductItem(null)
+                    .purchaseOrderProduct(null)
                     .receivedQuantity(itemDto.getQuantity())
                     .description(itemDto.getDescription())
                     .build();

--- a/src/main/java/com/fourweekdays/fourweekdays/product/service/ProductService.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/product/service/ProductService.java
@@ -45,8 +45,6 @@ public class ProductService {
             throw new ProductException(PRODUCT_DUPLICATION);
         }
 
-
-
         Product product = requestDto.toEntity(codeGenerator.generate(PRODUCT_CODE_PREFIX));
         product.mappingVendor(vendor); // 연관 관계 매핑 
         return productRepository.save(product).getId();

--- a/src/main/java/com/fourweekdays/fourweekdays/product/service/ProductService.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/product/service/ProductService.java
@@ -28,7 +28,7 @@ import static com.fourweekdays.fourweekdays.vendor.exception.VendorExceptionType
 @Transactional(readOnly = true)
 public class ProductService {
 
-    private static final String PRODUCT_CODE_PREFIX = "PO";
+    private static final String PRODUCT_CODE_PREFIX = "PRD";
 
     private final ProductRepository productRepository;
     private final VendorRepository vendorRepository;

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/controller/PurchaseOrderController.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/controller/PurchaseOrderController.java
@@ -4,6 +4,7 @@ import com.fourweekdays.fourweekdays.common.BaseResponse;
 import com.fourweekdays.fourweekdays.purchaseorder.model.dto.request.PurchaseOrderCreateDto;
 import com.fourweekdays.fourweekdays.purchaseorder.model.dto.response.PurchaseOrderReadDto;
 import com.fourweekdays.fourweekdays.purchaseorder.service.PurchaseOrderService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,7 +19,7 @@ public class PurchaseOrderController {
     private final PurchaseOrderService purchaseOrderService;
 
     @PostMapping
-    public ResponseEntity<BaseResponse<Long>> purchaseRequest(@RequestBody PurchaseOrderCreateDto requestDto) {
+    public ResponseEntity<BaseResponse<Long>> purchaseRequest(@Valid @RequestBody PurchaseOrderCreateDto requestDto) {
         return ResponseEntity.ok(BaseResponse.success(purchaseOrderService.create(requestDto)));
     }
 

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/controller/PurchaseOrderController.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/controller/PurchaseOrderController.java
@@ -6,6 +6,7 @@ import com.fourweekdays.fourweekdays.purchaseorder.model.dto.response.PurchaseOr
 import com.fourweekdays.fourweekdays.purchaseorder.service.PurchaseOrderService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -23,13 +24,14 @@ public class PurchaseOrderController {
         return ResponseEntity.ok(BaseResponse.success(purchaseOrderService.create(requestDto)));
     }
 
-    @GetMapping
-    public ResponseEntity<BaseResponse<List<PurchaseOrderReadDto>>> purchaseOrderList() {
-        return ResponseEntity.ok(BaseResponse.success(purchaseOrderService.findAll()));
-    }
-
     @GetMapping("/{id}")
     public ResponseEntity<BaseResponse<PurchaseOrderReadDto>> purchaseOrderDetail(@PathVariable Long id) {
         return ResponseEntity.ok(BaseResponse.success(purchaseOrderService.findByPurchaseOrderId(id)));
+    }
+
+    @GetMapping
+    public ResponseEntity<BaseResponse<Page<PurchaseOrderReadDto>>> purchaseOrderList(@RequestParam(defaultValue = "0") int page,
+                                                                                      @RequestParam(defaultValue = "10") int size) {
+        return ResponseEntity.ok(BaseResponse.success(purchaseOrderService.findPurchaseOrderListByPaging(page, size)));
     }
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/controller/PurchaseOrderController.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/controller/PurchaseOrderController.java
@@ -41,4 +41,10 @@ public class PurchaseOrderController {
                                                                   @Valid @RequestBody PurchaseOrderUpdateDto requestDto) {
         return ResponseEntity.ok(BaseResponse.success(purchaseOrderService.update(id, requestDto)));
     }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<BaseResponse<String>> cancelOrder(@PathVariable Long id) {
+        purchaseOrderService.cancel(id);
+        return ResponseEntity.ok((BaseResponse.success("발주 취소")));
+    }
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/controller/PurchaseOrderController.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/controller/PurchaseOrderController.java
@@ -2,6 +2,7 @@ package com.fourweekdays.fourweekdays.purchaseorder.controller;
 
 import com.fourweekdays.fourweekdays.common.BaseResponse;
 import com.fourweekdays.fourweekdays.purchaseorder.model.dto.request.PurchaseOrderCreateDto;
+import com.fourweekdays.fourweekdays.purchaseorder.model.dto.request.PurchaseOrderUpdateDto;
 import com.fourweekdays.fourweekdays.purchaseorder.model.dto.response.PurchaseOrderReadDto;
 import com.fourweekdays.fourweekdays.purchaseorder.service.PurchaseOrderService;
 import jakarta.validation.Valid;
@@ -33,5 +34,11 @@ public class PurchaseOrderController {
     public ResponseEntity<BaseResponse<Page<PurchaseOrderReadDto>>> purchaseOrderList(@RequestParam(defaultValue = "0") int page,
                                                                                       @RequestParam(defaultValue = "10") int size) {
         return ResponseEntity.ok(BaseResponse.success(purchaseOrderService.findPurchaseOrderListByPaging(page, size)));
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<BaseResponse<Long>> updatePurchaseOrder(@PathVariable Long id,
+                                                                  @Valid @RequestBody PurchaseOrderUpdateDto requestDto) {
+        return ResponseEntity.ok(BaseResponse.success(purchaseOrderService.update(id, requestDto)));
     }
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/exception/PurchaseOrderExceptionType.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/exception/PurchaseOrderExceptionType.java
@@ -3,11 +3,14 @@ package com.fourweekdays.fourweekdays.purchaseorder.exception;
 import com.fourweekdays.fourweekdays.global.exception.ExceptionType;
 import org.springframework.http.HttpStatus;
 
+import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 public enum PurchaseOrderExceptionType implements ExceptionType {
 
-    PURCHASE_ORDER_NOT_FOUND(NOT_FOUND, "해당 발주서를 찾을 수 없습니다.");
+    PURCHASE_ORDER_NOT_FOUND(NOT_FOUND, "해당 발주서를 찾을 수 없습니다."),
+
+    PURCHASE_ORDER_CANNOT_UPDATE_AFTER_APPROVAL(CONFLICT, "이미 승인된 발주서는 수정할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/exception/PurchaseOrderExceptionType.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/exception/PurchaseOrderExceptionType.java
@@ -10,7 +10,8 @@ public enum PurchaseOrderExceptionType implements ExceptionType {
 
     PURCHASE_ORDER_NOT_FOUND(NOT_FOUND, "해당 발주서를 찾을 수 없습니다."),
 
-    PURCHASE_ORDER_CANNOT_UPDATE_AFTER_APPROVAL(CONFLICT, "이미 승인된 발주서는 수정할 수 없습니다.");
+    PURCHASE_ORDER_CANNOT_UPDATE_AFTER_APPROVAL(CONFLICT, "이미 승인된 발주서는 수정할 수 없습니다."),
+    PURCHASE_ORDER_CANNOT_CANCEL_AFTER_APPROVAL(CONFLICT, "이미 승인된 발주서는 취소할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/request/PurchaseOrderCreateDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/request/PurchaseOrderCreateDto.java
@@ -26,7 +26,7 @@ public class PurchaseOrderCreateDto {
     private LocalDateTime expectedDate; // 입고 예정일
 
     @NotEmpty(message = "발주 상품을 선택해주세요.")
-    private List<PurchaseOrderItemRequestDto> items;
+    private List<PurchaseOrderProductRequestDto> items;
 
     @Size(max = 1000, message = "비고는 1000자 이내로 입력해주세요")
     private String description;

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/request/PurchaseOrderCreateDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/request/PurchaseOrderCreateDto.java
@@ -19,9 +19,6 @@ public class PurchaseOrderCreateDto {
     @NotNull(message = "공급업체를 선택해주세요")
     private Long vendorId; // 공급업체 ID
 
-    @NotNull(message = "발주일을 입력해주세요")
-    private LocalDateTime orderDate; // 발주일
-
     @NotNull(message = "입고 예정일을 입력해주세요")
     private LocalDateTime expectedDate; // 입고 예정일
 
@@ -30,15 +27,4 @@ public class PurchaseOrderCreateDto {
 
     @Size(max = 1000, message = "비고는 1000자 이내로 입력해주세요")
     private String description;
-
-    // TODO: 다른 엔티티가 정의되면 리팩토링
-    public PurchaseOrder toEntity(Vendor vendor) {
-        return PurchaseOrder.builder()
-                .vendor(vendor)
-                .status(PurchaseOrderStatus.REQUESTED)
-                .orderDate(this.orderDate)
-                .expectedDate(this.expectedDate)
-                .description(this.description)
-                .build();
-    }
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/request/PurchaseOrderProductRequestDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/request/PurchaseOrderProductRequestDto.java
@@ -9,7 +9,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class PurchaseOrderItemRequestDto {
+public class PurchaseOrderProductRequestDto {
 
     @NotNull(message = "상품 ID를 입력하세요.")
     private Long productId;

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/request/PurchaseOrderUpdateDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/request/PurchaseOrderUpdateDto.java
@@ -1,0 +1,21 @@
+package com.fourweekdays.fourweekdays.purchaseorder.model.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record PurchaseOrderUpdateDto(
+        @Future(message = "입고 예정일은 미래여야 합니다")
+        LocalDateTime expectedDate,
+
+        @Size(max = 1000, message = "비고는 1000자 이내로 입력해주세요")
+        String description,
+
+        @Valid
+        List<PurchaseOrderProductRequestDto> items
+) {
+
+}

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/response/PurchaseOrderItemResponseDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/response/PurchaseOrderItemResponseDto.java
@@ -1,6 +1,6 @@
 package com.fourweekdays.fourweekdays.purchaseorder.model.dto.response;
 
-import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrderProductItem;
+import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrderProduct;
 import lombok.Builder;
 
 @Builder
@@ -10,7 +10,7 @@ public record PurchaseOrderItemResponseDto(
         Integer orderedQuantity,
         String description
 ) {
-    public static PurchaseOrderItemResponseDto toDto(PurchaseOrderProductItem item) {
+    public static PurchaseOrderItemResponseDto toDto(PurchaseOrderProduct item) {
         return PurchaseOrderItemResponseDto.builder()
                 .id(item.getId())
                 .productName(item.getProduct().getName())

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/response/PurchaseOrderProductResponseDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/response/PurchaseOrderProductResponseDto.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 @Builder
 public record PurchaseOrderProductResponseDto(
         Long id,
+        Long productId,
         String productName,
         Integer orderedQuantity,
         String description
@@ -13,6 +14,7 @@ public record PurchaseOrderProductResponseDto(
     public static PurchaseOrderProductResponseDto toDto(PurchaseOrderProduct item) {
         return PurchaseOrderProductResponseDto.builder()
                 .id(item.getId())
+                .productId(item.getProduct().getId())
                 .productName(item.getProduct().getName())
                 .orderedQuantity(item.getOrderedQuantity())
                 .description(item.getDescription())

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/response/PurchaseOrderProductResponseDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/response/PurchaseOrderProductResponseDto.java
@@ -4,14 +4,14 @@ import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrderPro
 import lombok.Builder;
 
 @Builder
-public record PurchaseOrderItemResponseDto(
+public record PurchaseOrderProductResponseDto(
         Long id,
         String productName,
         Integer orderedQuantity,
         String description
 ) {
-    public static PurchaseOrderItemResponseDto toDto(PurchaseOrderProduct item) {
-        return PurchaseOrderItemResponseDto.builder()
+    public static PurchaseOrderProductResponseDto toDto(PurchaseOrderProduct item) {
+        return PurchaseOrderProductResponseDto.builder()
                 .id(item.getId())
                 .productName(item.getProduct().getName())
                 .orderedQuantity(item.getOrderedQuantity())

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/response/PurchaseOrderReadDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/response/PurchaseOrderReadDto.java
@@ -28,7 +28,7 @@ public class PurchaseOrderReadDto {
     public static PurchaseOrderReadDto toDto(PurchaseOrder entity) {
         return PurchaseOrderReadDto.builder()
                 .id(entity.getId())
-                .orderNumber(entity.getOrderNumber())
+                .orderNumber(entity.getOrderCode())
                 .vendorName(entity.getVendor().getName())
                 .orderDate(entity.getOrderDate())
                 .expectedDate(entity.getExpectedDate())

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/response/PurchaseOrderReadDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/response/PurchaseOrderReadDto.java
@@ -33,7 +33,7 @@ public class PurchaseOrderReadDto {
                 .orderDate(entity.getOrderDate())
                 .expectedDate(entity.getExpectedDate())
                 .status(entity.getStatus())
-                .totalAmount(entity.getTotalAmount())
+                .totalAmount(entity.calculateTotalAmount())
                 .description(entity.getDescription())
                 .items(entity.getItems().stream()
                         .map(PurchaseOrderProductResponseDto::toDto)

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/response/PurchaseOrderReadDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/response/PurchaseOrderReadDto.java
@@ -23,7 +23,7 @@ public class PurchaseOrderReadDto {
     private final PurchaseOrderStatus status; // 상태
     private final Long totalAmount; // 총 금액
     private final String description; // 비고
-    private final List<PurchaseOrderItemResponseDto> items; // 발주 상품 목록
+    private final List<PurchaseOrderProductResponseDto> items; // 발주 상품 목록
 
     public static PurchaseOrderReadDto toDto(PurchaseOrder entity) {
         return PurchaseOrderReadDto.builder()
@@ -36,7 +36,7 @@ public class PurchaseOrderReadDto {
                 .totalAmount(entity.getTotalAmount())
                 .description(entity.getDescription())
                 .items(entity.getItems().stream()
-                        .map(PurchaseOrderItemResponseDto::toDto)
+                        .map(PurchaseOrderProductResponseDto::toDto)
                         .toList())
                 .build();
     }

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/entity/PurchaseOrder.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/entity/PurchaseOrder.java
@@ -21,7 +21,7 @@ public class PurchaseOrder extends BaseEntity {
     private Long id;
 
     @Column(nullable = false, unique = true, length = 50)
-    private String orderNumber; // 발주번호 (예: PO-20250415-001)
+    private String orderCode; // 발주번호 (예: PO-20250415-001)
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "vendor_id", nullable = false)

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/entity/PurchaseOrder.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/entity/PurchaseOrder.java
@@ -68,6 +68,10 @@ public class PurchaseOrder extends BaseEntity {
     public void clearItems() {
         this.items.clear(); // orphanRemoval = true 설정 시 자동 삭제
     }
+
+    public void cancel() {
+        this.status = PurchaseOrderStatus.CANCELLED;
+    }
     // ... 발주 승인 메서드 ...
     // ... 발주 확정 메서드 ...
     // ... 입고 완료 처리 메서드 ...

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/entity/PurchaseOrder.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/entity/PurchaseOrder.java
@@ -40,9 +40,6 @@ public class PurchaseOrder extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private PurchaseOrderStatus status;
 
-    @Column(nullable = false)
-    private Long totalAmount; // 총 금액
-
     @Column(length = 1000)
     private String description; // 비고
 
@@ -50,11 +47,18 @@ public class PurchaseOrder extends BaseEntity {
 //    private String orderedBy; // 발주 담당자
 
     // ===== 연관관계 편의 메서드 ===== //
-    // ... 상품 추가 메서드 ...
+    public void addItem(PurchaseOrderProduct purchaseOrderProduct) {
+        this.items.add(purchaseOrderProduct);
+        purchaseOrderProduct.mappingPurchaseOrder(this);
+    }
     // ... 상품 제거 메서드 ...
 
     // ===== 비즈니스 로직 ===== //
-    // ... 총액 계산 메서드 ...
+    public Long calculateTotalAmount() {
+        return items.stream()
+                .mapToLong(PurchaseOrderProduct::calculateAmount)
+                .sum();
+    }
     // ... 발주 승인 메서드 ...
     // ... 발주 확정 메서드 ...
     // ... 입고 완료 처리 메서드 ...

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/entity/PurchaseOrder.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/entity/PurchaseOrder.java
@@ -59,6 +59,15 @@ public class PurchaseOrder extends BaseEntity {
                 .mapToLong(PurchaseOrderProduct::calculateAmount)
                 .sum();
     }
+
+    public void update(LocalDateTime expectedDate, String description) {
+        if (expectedDate != null) this.expectedDate = expectedDate;
+        if (description != null) this.description = description;
+    }
+
+    public void clearItems() {
+        this.items.clear(); // orphanRemoval = true 설정 시 자동 삭제
+    }
     // ... 발주 승인 메서드 ...
     // ... 발주 확정 메서드 ...
     // ... 입고 완료 처리 메서드 ...

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/entity/PurchaseOrder.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/entity/PurchaseOrder.java
@@ -29,7 +29,7 @@ public class PurchaseOrder extends BaseEntity {
 
     @Builder.Default
     @OneToMany(mappedBy = "purchaseOrder", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<PurchaseOrderProductItem> items = new ArrayList<>();
+    private List<PurchaseOrderProduct> items = new ArrayList<>();
 
     @Column(nullable = false)
     private LocalDateTime orderDate; // 발주일

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/entity/PurchaseOrderProduct.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/entity/PurchaseOrderProduct.java
@@ -30,11 +30,16 @@ public class PurchaseOrderProduct extends BaseEntity {
     @Column(length = 500)
     private String description; // 비고
 
+
     // ===== 연관관계 편의 메서드 ===== //
-    // ... PurchaseOrder 할당 메서드 ...
+    public void mappingPurchaseOrder(PurchaseOrder purchaseOrder) {
+        this.purchaseOrder = purchaseOrder;
+    }
 
     // ===== 비즈니스 로직 ===== //
-    // ... 총액 계산 메서드 (product.getUnitPrice() * orderedQuantity) ...
+    public Long calculateAmount() {
+        return this.product.getUnitPrice() * orderedQuantity;
+    }
     // ... 입고 진행률 조회 메서드 (Inbound에서 집계) ...
 }
 

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/entity/PurchaseOrderProduct.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/entity/PurchaseOrderProduct.java
@@ -10,7 +10,7 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class PurchaseOrderProductItem extends BaseEntity {
+public class PurchaseOrderProduct extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/entity/PurchaseOrderStatus.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/entity/PurchaseOrderStatus.java
@@ -5,8 +5,8 @@ import lombok.Getter;
 @Getter
 public enum PurchaseOrderStatus {
 //    DRAFT("임시저장"), // 작성중
-    REQUESTED("발주요청"), // 승인 대기
-    APPROVED("승인완료"), // 승인됨
+    REQUESTED("발주 요청"), // 승인 대기
+    APPROVED("승인 완료"), // 승인됨
 //    ORDERED("발주완료"), // 공급업체에 발주함
 //    PARTIALLY_RECEIVED("부분입고"),
     COMPLETED("완료"), // 입고 완료

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/repository/PurchaseOrderRepository.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/repository/PurchaseOrderRepository.java
@@ -3,5 +3,5 @@ package com.fourweekdays.fourweekdays.purchaseorder.repository;
 import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrder;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PurchaseOrderRepository extends JpaRepository<PurchaseOrder, Long> {
+public interface PurchaseOrderRepository extends JpaRepository<PurchaseOrder, Long>, PurchaseOrderRepositoryCustom {
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/repository/PurchaseOrderRepositoryCustom.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/repository/PurchaseOrderRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.fourweekdays.fourweekdays.purchaseorder.repository;
+
+import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrder;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PurchaseOrderRepositoryCustom {
+
+    Page<PurchaseOrder> findAllWithPaging(Pageable pageable);
+}

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/repository/PurchaseOrderRepositoryCustomImpl.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/repository/PurchaseOrderRepositoryCustomImpl.java
@@ -1,0 +1,38 @@
+package com.fourweekdays.fourweekdays.purchaseorder.repository;
+
+import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrder;
+import com.fourweekdays.fourweekdays.purchaseorder.model.entity.QPurchaseOrder;
+import com.fourweekdays.fourweekdays.vendor.model.entity.Vendor;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static com.fourweekdays.fourweekdays.purchaseorder.model.entity.QPurchaseOrder.purchaseOrder;
+import static com.fourweekdays.fourweekdays.vendor.model.entity.QVendor.vendor;
+
+@RequiredArgsConstructor
+public class PurchaseOrderRepositoryCustomImpl implements PurchaseOrderRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<PurchaseOrder> findAllWithPaging(Pageable pageable) {
+        List<PurchaseOrder> purchaseOrderList = queryFactory
+                .selectFrom(purchaseOrder)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(purchaseOrder.createdAt.desc())
+                .fetch();
+
+        Long total = queryFactory
+                .select(purchaseOrder.count())
+                .from(purchaseOrder)
+                .fetchOne();
+
+        return new PageImpl<>(purchaseOrderList, pageable, total);
+    }
+}

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/service/PurchaseOrderService.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/service/PurchaseOrderService.java
@@ -85,6 +85,7 @@ public class PurchaseOrderService {
         return purchaseOrder.getId();
     }
 
+    @Transactional
     public void cancel(Long id) {
         PurchaseOrder purchaseOrder = purchaseOrderRepository.findById(id)
                 .orElseThrow(() -> new PurchaseOrderException(PURCHASE_ORDER_NOT_FOUND));

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/service/PurchaseOrderService.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/service/PurchaseOrderService.java
@@ -1,31 +1,49 @@
 package com.fourweekdays.fourweekdays.purchaseorder.service;
 
+import com.fourweekdays.fourweekdays.common.generator.CodeGenerator;
+import com.fourweekdays.fourweekdays.product.exception.ProductException;
+import com.fourweekdays.fourweekdays.product.model.entity.Product;
+import com.fourweekdays.fourweekdays.product.repository.ProductRepository;
 import com.fourweekdays.fourweekdays.purchaseorder.model.dto.request.PurchaseOrderCreateDto;
+import com.fourweekdays.fourweekdays.purchaseorder.model.dto.request.PurchaseOrderProductRequestDto;
 import com.fourweekdays.fourweekdays.purchaseorder.model.dto.response.PurchaseOrderReadDto;
 import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrder;
+import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrderProduct;
+import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrderStatus;
 import com.fourweekdays.fourweekdays.purchaseorder.repository.PurchaseOrderRepository;
+import com.fourweekdays.fourweekdays.vendor.exception.VendorException;
 import com.fourweekdays.fourweekdays.vendor.model.entity.Vendor;
 import com.fourweekdays.fourweekdays.vendor.repository.VendorRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
+
+import static com.fourweekdays.fourweekdays.product.exception.ProductExceptionType.PRODUCT_NOT_FOUND;
+import static com.fourweekdays.fourweekdays.vendor.exception.VendorExceptionType.VENDOR_NOT_FOUND;
 
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
 public class PurchaseOrderService {
 
+    private static final String PURCHASE_ORDER_CODE_PREFIX = "PO";
+
     private final PurchaseOrderRepository purchaseOrderRepository;
     private final VendorRepository vendorRepository;
+    private final ProductRepository productRepository;
+    private final CodeGenerator codeGenerator;
 
     @Transactional
     public Long create(PurchaseOrderCreateDto requestDto) {
         Vendor vendor = vendorRepository.findById(requestDto.getVendorId())
-                .orElseThrow(() -> new IllegalArgumentException("공급 업체를 찾을 수 없습니다."));
+                .orElseThrow(() -> new VendorException(VENDOR_NOT_FOUND));
 
-        PurchaseOrder purchaseOrder = requestDto.toEntity(vendor);
+        PurchaseOrder purchaseOrder = createPurchaseOrder(vendor, requestDto);
+        createOrderProducts(requestDto.getItems(), purchaseOrder);
+
         return purchaseOrderRepository.save(purchaseOrder).getId();
     }
 
@@ -40,5 +58,37 @@ public class PurchaseOrderService {
         return purchaseOrderRepository.findAll().stream()
                 .map(PurchaseOrderReadDto::toDto)
                 .toList();
+    }
+
+
+    private PurchaseOrder createPurchaseOrder(Vendor vendor, PurchaseOrderCreateDto dto) {
+        return PurchaseOrder.builder()
+                .vendor(vendor)
+                .orderCode(codeGenerator.generate(PURCHASE_ORDER_CODE_PREFIX))
+                .orderDate(LocalDateTime.now())
+                .expectedDate(dto.getExpectedDate())
+                .description(dto.getDescription())
+                .status(PurchaseOrderStatus.REQUESTED)
+                .build();
+    }
+
+    private List<PurchaseOrderProduct> createOrderProducts(List<PurchaseOrderProductRequestDto> items, PurchaseOrder purchaseOrder) {
+        return items.stream()
+                .map(item -> createOrderProduct(item, purchaseOrder))
+                .toList();
+    }
+
+    private PurchaseOrderProduct createOrderProduct(PurchaseOrderProductRequestDto dto, PurchaseOrder purchaseOrder) {
+        Product product = productRepository.findById(dto.getProductId())
+                .orElseThrow(() -> new ProductException(PRODUCT_NOT_FOUND));
+
+        PurchaseOrderProduct orderProduct = PurchaseOrderProduct.builder()
+                .product(product)
+                .orderedQuantity(dto.getOrderedQuantity())
+                .description(dto.getDescription())
+                .build();
+
+        purchaseOrder.addItem(orderProduct);
+        return orderProduct;
     }
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/service/PurchaseOrderService.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/service/PurchaseOrderService.java
@@ -5,6 +5,7 @@ import com.fourweekdays.fourweekdays.product.exception.ProductException;
 import com.fourweekdays.fourweekdays.product.model.entity.Product;
 import com.fourweekdays.fourweekdays.product.repository.ProductRepository;
 import com.fourweekdays.fourweekdays.purchaseorder.exception.PurchaseOrderException;
+import com.fourweekdays.fourweekdays.purchaseorder.exception.PurchaseOrderExceptionType;
 import com.fourweekdays.fourweekdays.purchaseorder.model.dto.request.PurchaseOrderCreateDto;
 import com.fourweekdays.fourweekdays.purchaseorder.model.dto.request.PurchaseOrderProductRequestDto;
 import com.fourweekdays.fourweekdays.purchaseorder.model.dto.request.PurchaseOrderUpdateDto;
@@ -27,8 +28,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.fourweekdays.fourweekdays.product.exception.ProductExceptionType.PRODUCT_NOT_FOUND;
-import static com.fourweekdays.fourweekdays.purchaseorder.exception.PurchaseOrderExceptionType.PURCHASE_ORDER_CANNOT_UPDATE_AFTER_APPROVAL;
-import static com.fourweekdays.fourweekdays.purchaseorder.exception.PurchaseOrderExceptionType.PURCHASE_ORDER_NOT_FOUND;
+import static com.fourweekdays.fourweekdays.purchaseorder.exception.PurchaseOrderExceptionType.*;
 import static com.fourweekdays.fourweekdays.vendor.exception.VendorExceptionType.VENDOR_NOT_FOUND;
 
 @Transactional(readOnly = true)
@@ -83,6 +83,17 @@ public class PurchaseOrderService {
         createOrderProducts(requestDto.items(), purchaseOrder);
 
         return purchaseOrder.getId();
+    }
+
+    public void cancel(Long id) {
+        PurchaseOrder purchaseOrder = purchaseOrderRepository.findById(id)
+                .orElseThrow(() -> new PurchaseOrderException(PURCHASE_ORDER_NOT_FOUND));
+
+        if (!purchaseOrder.getStatus().equals(PurchaseOrderStatus.REQUESTED)) {
+            throw new PurchaseOrderException(PURCHASE_ORDER_CANNOT_CANCEL_AFTER_APPROVAL);
+        }
+
+        purchaseOrder.cancel();
     }
 
 

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/service/PurchaseOrderService.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/service/PurchaseOrderService.java
@@ -4,6 +4,8 @@ import com.fourweekdays.fourweekdays.common.generator.CodeGenerator;
 import com.fourweekdays.fourweekdays.product.exception.ProductException;
 import com.fourweekdays.fourweekdays.product.model.entity.Product;
 import com.fourweekdays.fourweekdays.product.repository.ProductRepository;
+import com.fourweekdays.fourweekdays.purchaseorder.exception.PurchaseOrderException;
+import com.fourweekdays.fourweekdays.purchaseorder.exception.PurchaseOrderExceptionType;
 import com.fourweekdays.fourweekdays.purchaseorder.model.dto.request.PurchaseOrderCreateDto;
 import com.fourweekdays.fourweekdays.purchaseorder.model.dto.request.PurchaseOrderProductRequestDto;
 import com.fourweekdays.fourweekdays.purchaseorder.model.dto.response.PurchaseOrderReadDto;
@@ -15,6 +17,9 @@ import com.fourweekdays.fourweekdays.vendor.exception.VendorException;
 import com.fourweekdays.fourweekdays.vendor.model.entity.Vendor;
 import com.fourweekdays.fourweekdays.vendor.repository.VendorRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +27,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.fourweekdays.fourweekdays.product.exception.ProductExceptionType.PRODUCT_NOT_FOUND;
+import static com.fourweekdays.fourweekdays.purchaseorder.exception.PurchaseOrderExceptionType.PURCHASE_ORDER_NOT_FOUND;
 import static com.fourweekdays.fourweekdays.vendor.exception.VendorExceptionType.VENDOR_NOT_FOUND;
 
 @Transactional(readOnly = true)
@@ -49,15 +55,15 @@ public class PurchaseOrderService {
 
     public PurchaseOrderReadDto findByPurchaseOrderId(Long id) {
         PurchaseOrder purchaseOrder = purchaseOrderRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 발주를 찾을 수 없습니다. id=" + id));
+                .orElseThrow(() -> new PurchaseOrderException(PURCHASE_ORDER_NOT_FOUND));
 
         return PurchaseOrderReadDto.toDto(purchaseOrder);
     }
 
-    public List<PurchaseOrderReadDto> findAll() {
-        return purchaseOrderRepository.findAll().stream()
-                .map(PurchaseOrderReadDto::toDto)
-                .toList();
+    public Page<PurchaseOrderReadDto> findPurchaseOrderListByPaging(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<PurchaseOrder> purchaseOrderList = purchaseOrderRepository.findAllWithPaging(pageable);
+        return purchaseOrderList.map(PurchaseOrderReadDto::toDto);
     }
 
 

--- a/src/main/java/com/fourweekdays/fourweekdays/tasks/Task.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/tasks/Task.java
@@ -50,3 +50,8 @@ public class Task extends BaseEntity {
     private LocalDateTime completedAt; // 작업 완료일시
 
 }
+
+
+// 1. enum type만 알려준다
+// 2. jpa 상속전략을 사용한다.
+// 3. 합성

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
   jpa:
     #    show-sql: true
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
 
   cloud:
     aws:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,8 @@ spring:
   jpa:
     #    show-sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
+
   cloud:
     aws:
       credentials:

--- a/src/test/java/com/fourweekdays/fourweekdays/purchaseorder/service/PurchaseOrderServiceTest.java
+++ b/src/test/java/com/fourweekdays/fourweekdays/purchaseorder/service/PurchaseOrderServiceTest.java
@@ -1,0 +1,23 @@
+package com.fourweekdays.fourweekdays.purchaseorder.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class PurchaseOrderServiceTest {
+
+    @Test
+    @DisplayName("발주서를 생성한다.")
+    void create_purchase_order() {
+
+    }
+
+    @Test
+    @DisplayName("승인 완료된 발주서는 수정할 수 없다.")
+    void cannot_update_purchase_order_after_approval() {
+
+    }
+}


### PR DESCRIPTION
# 🧩 Issue
- #128 

## 📝 요약
- 발주(PurchaseOrder)에 대한 CRUD 구현입니다.

## 🔍 변경 사항
- 발주 관련 기본 CRUD를 구현했습니다.
- 발주-상품 중간 테이블 엔티티 이름을 PurchaserOrderProductItem -> PurchaserOrderProduct 로 변경했습니다. 
- 이름 변경으로 인한 초기 데이터 구현 부분이 변경되었습니다. 크게 중요한 것은 아닙니다.
- close #128

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수 했는가?
- [x] 커밋 내용에 시크릿 키 등의 공유되지 말아야 할 것들을 제거 했는가?

## 💬 기타 공유사항
- 의도 중복이라는 생각에 중간 테이블 엔티티 이름을 변경했습니다. 관련된 Dto들의 이름도 변경되었으니 참고 바랍니다. 
- 발주서 총액(totalAmount) 컬럼을 삭제하는 대신 관련 메서드를 추가했습니다. 이걸로 성능상 이슈가 생기면 다시 변경할 예정입니다.
- 이후에 담당자 컬럼인 Member와의 연관 관계 이후 로직 변경/추가가 있을 예정입니다. 