### PR TITLE
refactor: FranchiseReadDto 변경

### DIFF
--- a/src/main/java/com/fourweekdays/fourweekdays/franchise/model/dto/request/FranchiseUpdateDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/franchise/model/dto/request/FranchiseUpdateDto.java
@@ -1,12 +1,9 @@
 package com.fourweekdays.fourweekdays.franchise.model.dto.request;
 
 import com.fourweekdays.fourweekdays.common.vo.Address;
-import com.fourweekdays.fourweekdays.franchise.exception.FranchiseException;
 import com.fourweekdays.fourweekdays.franchise.model.entity.FranchiseStatus;
 import lombok.Builder;
 import lombok.Getter;
-
-import static com.fourweekdays.fourweekdays.franchise.exception.FranchiseExceptionType.FRANCHISE_INVALID_STATUS;
 
 @Getter
 @Builder

--- a/src/main/java/com/fourweekdays/fourweekdays/franchise/model/dto/response/FranchiseReadDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/franchise/model/dto/response/FranchiseReadDto.java
@@ -4,6 +4,8 @@ import com.fourweekdays.fourweekdays.common.vo.Address;
 import com.fourweekdays.fourweekdays.franchise.model.entity.FranchiseStore;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Builder
 public class FranchiseReadDto {
@@ -15,6 +17,8 @@ public class FranchiseReadDto {
     private String description;
     private Address address;
     private String status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 
     public static FranchiseReadDto from(FranchiseStore entity) {
         return FranchiseReadDto.builder()
@@ -26,6 +30,8 @@ public class FranchiseReadDto {
                 .description(entity.getDescription())
                 .address(entity.getAddress())
                 .status(entity.getStatus().toString())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
                 .build();
     }
 }


### PR DESCRIPTION
# 🧩 Issue
#52 

## 📝 요약
FranchiseReadDto 변경

## 🔍 변경 사항
- refactor : FranchiseReadDto private LocalDateTime createdAt private LocalDateTime updatedAt 추가
- refactor : FranchiseUpdateDto 사용하지 않는 import 제거
- 관련 이슈: #52

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수 했는가?
- [x] 커밋 내용에 시크릿 키 등의 공유되지 말아야 할 것들을 제거 했는가?

## 💬 기타 공유사항
프론트 작업하면서 필요하다고 느낀 데이터를 전달하도록 변경했습니다.