### PR TITLE
refactor: purchase 비즈니스 로직 및 엔티티 변경

### DIFF
--- a/src/main/java/com/fourweekdays/fourweekdays/member/config/SecurityConfig.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/member/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
         configuration.setAllowedOrigins(List.of(
                 "http://localhost:5173"
         ));
-        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/fourweekdays/fourweekdays/product/repository/ProductRepository.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/product/repository/ProductRepository.java
@@ -1,10 +1,19 @@
 package com.fourweekdays.fourweekdays.product.repository;
 
 import com.fourweekdays.fourweekdays.product.model.entity.Product;
+import com.fourweekdays.fourweekdays.product.model.entity.ProductStatus;
 import com.fourweekdays.fourweekdays.vendor.model.entity.Vendor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductRepository extends JpaRepository<Product, Long>, ProductRepositoryCustom {
 
     boolean existsByVendorAndName(Vendor vendor, String name);
+
+    // ✅ ACTIVE 상태 필터용
+    Page<Product> findByStatus(ProductStatus status, Pageable pageable);
+
+    // ✅ 특정 공급업체 + ACTIVE 상태 필터용
+    Page<Product> findByVendorIdAndStatus(Long vendorId, ProductStatus status, Pageable pageable);
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/exception/PurchaseOrderExceptionType.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/exception/PurchaseOrderExceptionType.java
@@ -3,15 +3,19 @@ package com.fourweekdays.fourweekdays.purchaseorder.exception;
 import com.fourweekdays.fourweekdays.global.exception.ExceptionType;
 import org.springframework.http.HttpStatus;
 
-import static org.springframework.http.HttpStatus.CONFLICT;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.*;
 
 public enum PurchaseOrderExceptionType implements ExceptionType {
 
     PURCHASE_ORDER_NOT_FOUND(NOT_FOUND, "해당 발주서를 찾을 수 없습니다."),
 
     PURCHASE_ORDER_CANNOT_UPDATE_AFTER_APPROVAL(CONFLICT, "이미 승인된 발주서는 수정할 수 없습니다."),
-    PURCHASE_ORDER_CANNOT_CANCEL_AFTER_APPROVAL(CONFLICT, "이미 승인된 발주서는 취소할 수 없습니다.");
+    PURCHASE_ORDER_CANNOT_CANCEL_AFTER_APPROVAL(CONFLICT, "이미 승인된 발주서는 취소할 수 없습니다."),
+    PURCHASE_ORDER_INVALID_STATUS_CHANGE(CONFLICT, "현재 상태에서는 요청하신 상태로 변경할 수 없습니다."),
+
+    PURCHASE_ORDER_TOTAL_AMOUNT_ERROR(INTERNAL_SERVER_ERROR, "총 금액 계산 중 오류가 발생했습니다."),
+    PURCHASE_ORDER_PRODUCT_NOT_FOUND(NOT_FOUND, "발주 품목에 해당 상품이 존재하지 않습니다."),
+    PURCHASE_ORDER_VENDOR_MISMATCH(BAD_REQUEST, "선택한 공급업체와 상품의 공급업체가 일치하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/response/PurchaseOrderProductResponseDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/response/PurchaseOrderProductResponseDto.java
@@ -8,6 +8,7 @@ public record PurchaseOrderProductResponseDto(
         Long id,
         Long productId,
         String productName,
+        Long unitPrice,
         Integer orderedQuantity,
         String description
 ) {
@@ -16,6 +17,7 @@ public record PurchaseOrderProductResponseDto(
                 .id(item.getId())
                 .productId(item.getProduct().getId())
                 .productName(item.getProduct().getName())
+                .unitPrice(item.getProduct().getUnitPrice())
                 .orderedQuantity(item.getOrderedQuantity())
                 .description(item.getDescription())
                 .build();

--- a/src/main/java/com/fourweekdays/fourweekdays/vendor/controller/VendorController.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/vendor/controller/VendorController.java
@@ -2,6 +2,7 @@ package com.fourweekdays.fourweekdays.vendor.controller;
 
 import com.fourweekdays.fourweekdays.common.BaseResponse;
 import com.fourweekdays.fourweekdays.vendor.model.dto.request.VendorCreateDto;
+import com.fourweekdays.fourweekdays.vendor.model.dto.request.VendorStatusUpdateDto;
 import com.fourweekdays.fourweekdays.vendor.model.dto.request.VendorUpdateDto;
 import com.fourweekdays.fourweekdays.vendor.model.dto.response.VendorReadDto;
 import com.fourweekdays.fourweekdays.vendor.service.VendorService;
@@ -10,8 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/vendors")
@@ -35,15 +34,23 @@ public class VendorController {
     @GetMapping
     public ResponseEntity<BaseResponse<Page<VendorReadDto>>> readVendors(@RequestParam(defaultValue = "0") Integer page,
                                                                          @RequestParam(defaultValue = "10") Integer size) {
-
         Page<VendorReadDto> result = vendorService.readAll(page, size);
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 
+    // 내용 수정
     @PatchMapping("/{id}")
     public ResponseEntity<BaseResponse<Long>> updateVendor(@PathVariable Long id,
                                                            @Valid @RequestBody VendorUpdateDto dto) {
         vendorService.update(id, dto);
+        return ResponseEntity.ok(BaseResponse.success(id));
+    }
+
+    // 상태 변경
+    @PatchMapping("/{id}/status")
+    public ResponseEntity<BaseResponse<Long>> updateVendorStatus(@PathVariable Long id,
+                                                                 @Valid @RequestBody VendorStatusUpdateDto dto) {
+        vendorService.updateStatus(id, dto.getStatus());
         return ResponseEntity.ok(BaseResponse.success(id));
     }
 

--- a/src/main/java/com/fourweekdays/fourweekdays/vendor/model/dto/request/VendorStatusUpdateDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/vendor/model/dto/request/VendorStatusUpdateDto.java
@@ -1,0 +1,16 @@
+package com.fourweekdays.fourweekdays.vendor.model.dto.request;
+
+import com.fourweekdays.fourweekdays.vendor.model.entity.VendorStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class VendorStatusUpdateDto {
+
+    @NotNull(message = "상태 값은 필수입니다.")
+    private VendorStatus status;
+
+}

--- a/src/main/java/com/fourweekdays/fourweekdays/vendor/model/dto/request/VendorUpdateDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/vendor/model/dto/request/VendorUpdateDto.java
@@ -27,9 +27,6 @@ public class VendorUpdateDto {
 
     private String description;
 
-    @NotNull
-    private VendorStatus status;
-
     private Address address;
 }
 

--- a/src/main/java/com/fourweekdays/fourweekdays/vendor/model/entity/Vendor.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/vendor/model/entity/Vendor.java
@@ -1,7 +1,7 @@
 package com.fourweekdays.fourweekdays.vendor.model.entity;
 
-import com.fourweekdays.fourweekdays.common.vo.Address;
 import com.fourweekdays.fourweekdays.common.BaseEntity;
+import com.fourweekdays.fourweekdays.common.vo.Address;
 import com.fourweekdays.fourweekdays.product.model.entity.Product;
 import jakarta.persistence.*;
 import lombok.*;
@@ -55,21 +55,24 @@ public class Vendor extends BaseEntity {
 
     // ===== 비즈니스 로직 ===== //
     public void update(String name, String phoneNumber, String email,
-                       String description, VendorStatus status, Address address) {
+                       String description, Address address) {
         if (name != null) this.name = name;
         if (phoneNumber != null) this.phoneNumber = phoneNumber;
         if (email != null) this.email = email;
         if (description != null) this.description = description;
-        if (status != null) this.status = status;
         if (address != null) this.address = address;
     }
 
-    public void suspended() {
-        this.status = VendorStatus.SUSPENDED;
+    public void changeStatus(VendorStatus status) {
+        if (status != null) this.status = status;
     }
 
-    public boolean canOrder() {
-        return this.status == VendorStatus.ACTIVE;
-    }
+//    public void suspended() {
+//        this.status = VendorStatus.SUSPENDED;
+//    }
+//
+//    public boolean canOrder() {
+//        return this.status == VendorStatus.ACTIVE;
+//    }
 
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/vendor/service/VendorService.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/vendor/service/VendorService.java
@@ -6,6 +6,7 @@ import com.fourweekdays.fourweekdays.vendor.model.dto.request.VendorCreateDto;
 import com.fourweekdays.fourweekdays.vendor.model.dto.request.VendorUpdateDto;
 import com.fourweekdays.fourweekdays.vendor.model.dto.response.VendorReadDto;
 import com.fourweekdays.fourweekdays.vendor.model.entity.Vendor;
+import com.fourweekdays.fourweekdays.vendor.model.entity.VendorStatus;
 import com.fourweekdays.fourweekdays.vendor.repository.VendorRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -13,8 +14,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 import static com.fourweekdays.fourweekdays.vendor.exception.VendorExceptionType.VENDOR_NOT_FOUND;
 
@@ -47,20 +46,31 @@ public class VendorService {
         return vendors.map(VendorReadDto::from);
     }
 
+    // 내용 수정
     @Transactional
     public void update(Long id, VendorUpdateDto dto) {
         Vendor vendor = vendorRepository.findById(id)
                 .orElseThrow(() -> new VendorException(VENDOR_NOT_FOUND));
 
         vendor.update(dto.getName(), dto.getPhoneNumber(), dto.getEmail(),
-                dto.getDescription(), dto.getStatus(), dto.getAddress());
+                dto.getDescription(), dto.getAddress());
     }
 
+    // 상태 변경
+    @Transactional
+    public void updateStatus(Long id, VendorStatus status) {
+        Vendor vendor = vendorRepository.findById(id)
+                .orElseThrow(() -> new VendorException(VENDOR_NOT_FOUND));
+
+        vendor.changeStatus(status);
+    }
+
+    // 거래 중단
     @Transactional
     public void suspend(Long id) {
         Vendor vendor = vendorRepository.findById(id)
                 .orElseThrow(() -> new VendorException(VENDOR_NOT_FOUND));
-        vendor.suspended();
+        vendor.changeStatus(VendorStatus.SUSPENDED);
     }
 
 }


### PR DESCRIPTION
# 🧩 Issue
- #141 
## 📝 요약
purchaseCreate, purchaseList, purchaseDetail을 위해 비즈니스 로직 및 엔티티 변경
+
VendorUpdateDto 내 status 컬럼 제외(VendorStatusUpdateDto 내 status 컬럼 추가)
Vendor, VendorService 수정

## 🔍 변경 사항
* ProductRepository
Vendor-Product 연관관계 기반 조회 지원
프론트 발주 등록 시, 선택된 공급업체(vendorId)에 속한 상품만 표시

* ProductService
getProductList() 메서드에 vendorId 조건 기반 조회 로직 추가
단종(DISCONTINUED) 및 품절(INACTIVE) 상품은 필터링 제외

* PurchaseOrderProductResponseDto
상품 단가(unitPrice) 필드 신규 추가

* PurchaseOrderService
발주 상태 관련 로직 추가(주석 참고)

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수 했는가?
- [x] 커밋 내용에 시크릿 키 등의 공유되지 말아야 할 것들을 제거 했는가?

## 💬 기타 공유사항
>
+
프론트에서 Vendor 내 수정을 내용 수정 & 상태 수정 2가지로 나눠서 메소드 분리해뒀습니다.
상태 변경 및 내용 변경 시에 DB에 내용 적용되는 점 확인했으나 History테이블 추가 구현 필요할 수 있습니다.

branch관리 똑바로 하겠읍니다...ㅠ