### PR TITLE
feat: 상태에 따른 입고서 생성을 구현하고 Asn 수신 입고서 생성 조건 변경한다.

### DIFF
--- a/src/main/java/com/fourweekdays/fourweekdays/asn/controller/ASNController.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/asn/controller/ASNController.java
@@ -3,7 +3,7 @@ package com.fourweekdays.fourweekdays.asn.controller;
 import com.fourweekdays.fourweekdays.asn.annotation.AuthenticatedVendor;
 import com.fourweekdays.fourweekdays.asn.model.dto.request.AsnReceiveRequest;
 import com.fourweekdays.fourweekdays.asn.model.dto.request.PurchaseOrderRejectRequest;
-import com.fourweekdays.fourweekdays.asn.model.dto.response.ASNResponse;
+import com.fourweekdays.fourweekdays.asn.model.dto.response.AsnResponse;
 import com.fourweekdays.fourweekdays.asn.service.AsnService;
 import com.fourweekdays.fourweekdays.common.BaseResponse;
 import com.fourweekdays.fourweekdays.vendor.model.entity.Vendor;
@@ -34,12 +34,12 @@ public class ASNController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<BaseResponse<ASNResponse>> asnDetail(@PathVariable Long id) {
+    public ResponseEntity<BaseResponse<AsnResponse>> asnDetail(@PathVariable Long id) {
         return ResponseEntity.ok(BaseResponse.success(asnService.asnDetail(id)));
     }
 
     @GetMapping
-    public ResponseEntity<BaseResponse<Page<ASNResponse>>> asnList(@RequestParam(defaultValue = "0") int page,
+    public ResponseEntity<BaseResponse<Page<AsnResponse>>> asnList(@RequestParam(defaultValue = "0") int page,
                                                                    @RequestParam(defaultValue = "10") int size) {
         return ResponseEntity.ok(BaseResponse.success(asnService.asnListByPaging(page, size)));
     }

--- a/src/main/java/com/fourweekdays/fourweekdays/asn/controller/ASNController.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/asn/controller/ASNController.java
@@ -2,6 +2,7 @@ package com.fourweekdays.fourweekdays.asn.controller;
 
 import com.fourweekdays.fourweekdays.asn.annotation.AuthenticatedVendor;
 import com.fourweekdays.fourweekdays.asn.model.dto.request.AsnReceiveRequest;
+import com.fourweekdays.fourweekdays.asn.model.dto.request.PurchaseOrderRejectRequest;
 import com.fourweekdays.fourweekdays.asn.model.dto.response.ASNResponse;
 import com.fourweekdays.fourweekdays.asn.service.AsnService;
 import com.fourweekdays.fourweekdays.common.BaseResponse;
@@ -23,6 +24,13 @@ public class ASNController {
                                                            @RequestBody AsnReceiveRequest request) {
         asnService.receiveAsn(vendor, request);
         return ResponseEntity.ok(BaseResponse.success("발주 ASN 전송 성공"));
+    }
+
+    @PostMapping("/reject")
+    public ResponseEntity<BaseResponse<String>> rejectPurchaseOrder(@AuthenticatedVendor Vendor vendor,
+                                                                    @RequestBody PurchaseOrderRejectRequest request) {
+        asnService.rejectPurchaseOrderByVendor(vendor, request);
+        return ResponseEntity.ok(BaseResponse.success("배송 취소"));
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/fourweekdays/fourweekdays/asn/model/dto/request/PurchaseOrderRejectRequest.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/asn/model/dto/request/PurchaseOrderRejectRequest.java
@@ -1,0 +1,9 @@
+package com.fourweekdays.fourweekdays.asn.model.dto.request;
+
+import java.time.LocalDateTime;
+
+public record PurchaseOrderRejectRequest(
+        String orderCode,
+        String description
+) {
+}

--- a/src/main/java/com/fourweekdays/fourweekdays/asn/model/dto/response/AsnResponse.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/asn/model/dto/response/AsnResponse.java
@@ -1,6 +1,6 @@
 package com.fourweekdays.fourweekdays.asn.model.dto.response;
 
-import com.fourweekdays.fourweekdays.asn.model.entity.ASN;
+import com.fourweekdays.fourweekdays.asn.model.entity.Asn;
 import com.fourweekdays.fourweekdays.purchaseorder.model.dto.response.PurchaseOrderProductResponseDto;
 import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrder;
 import lombok.Builder;
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Builder
-public class ASNResponse {
+public class AsnResponse {
 
     private Long id;
     private String asnCode;
@@ -19,10 +19,10 @@ public class ASNResponse {
 
     private List<PurchaseOrderProductResponseDto> products;
 
-    public static ASNResponse toDto(ASN asn) {
+    public static AsnResponse toDto(Asn asn) {
         PurchaseOrder purchaseOrder = asn.getPurchaseOrder();
 
-        return ASNResponse.builder()
+        return AsnResponse.builder()
                 .id(asn.getId())
                 .asnCode(asn.getAsnCode())
                 .vendorName(asn.getVendor().getName())

--- a/src/main/java/com/fourweekdays/fourweekdays/asn/model/entity/Asn.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/asn/model/entity/Asn.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ASN extends BaseEntity {
+public class Asn extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -34,9 +34,9 @@ public class ASN extends BaseEntity {
     private String description; // 비고
 
 
-    public static ASN create(Vendor vendor, PurchaseOrder purchaseOrder,
+    public static Asn create(Vendor vendor, PurchaseOrder purchaseOrder,
                              String asnCode, LocalDateTime expectedDate, String description) {
-        ASN asn = new ASN();
+        Asn asn = new Asn();
         asn.vendor = vendor;
         asn.purchaseOrder = purchaseOrder;
         asn.asnCode = asnCode;

--- a/src/main/java/com/fourweekdays/fourweekdays/asn/repository/ASNRepository.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/asn/repository/ASNRepository.java
@@ -1,8 +1,0 @@
-package com.fourweekdays.fourweekdays.asn.repository;
-
-import com.fourweekdays.fourweekdays.asn.model.entity.ASN;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface ASNRepository extends JpaRepository<ASN, Long>, ASNRepositoryCustom {
-}
-

--- a/src/main/java/com/fourweekdays/fourweekdays/asn/repository/AsnRepository.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/asn/repository/AsnRepository.java
@@ -1,0 +1,8 @@
+package com.fourweekdays.fourweekdays.asn.repository;
+
+import com.fourweekdays.fourweekdays.asn.model.entity.Asn;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AsnRepository extends JpaRepository<Asn, Long>, AsnRepositoryCustom {
+}
+

--- a/src/main/java/com/fourweekdays/fourweekdays/asn/repository/AsnRepositoryCustom.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/asn/repository/AsnRepositoryCustom.java
@@ -1,11 +1,11 @@
 package com.fourweekdays.fourweekdays.asn.repository;
 
 
-import com.fourweekdays.fourweekdays.asn.model.entity.ASN;
+import com.fourweekdays.fourweekdays.asn.model.entity.Asn;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-public interface ASNRepositoryCustom {
+public interface AsnRepositoryCustom {
 
-    Page<ASN> findAllWithPaging(Pageable pageable);
+    Page<Asn> findAllWithPaging(Pageable pageable);
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/asn/repository/AsnRepositoryCustomImpl.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/asn/repository/AsnRepositoryCustomImpl.java
@@ -1,6 +1,6 @@
 package com.fourweekdays.fourweekdays.asn.repository;
 
-import com.fourweekdays.fourweekdays.asn.model.entity.ASN;
+import com.fourweekdays.fourweekdays.asn.model.entity.Asn;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -9,24 +9,25 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
-import static com.fourweekdays.fourweekdays.asn.model.entity.QASN.aSN;
+import static com.fourweekdays.fourweekdays.asn.model.entity.QAsn.asn;
+
 
 @RequiredArgsConstructor
-public class ASNRepositoryCustomImpl implements ASNRepositoryCustom {
+public class AsnRepositoryCustomImpl implements AsnRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<ASN> findAllWithPaging(Pageable pageable) {
-
-        List<ASN> result = queryFactory.selectFrom(aSN)
+    public Page<Asn> findAllWithPaging(Pageable pageable) {
+        
+        List<Asn> result = queryFactory.selectFrom(asn)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
-                .orderBy(aSN.createdAt.desc())
+                .orderBy(asn.createdAt.desc())
                 .fetch();
 
-        Long total = queryFactory.select(aSN.count())
-                .from(aSN)
+        Long total = queryFactory.select(asn.count())
+                .from(asn)
                 .fetchOne();
 
         return new PageImpl<>(result, pageable, total);

--- a/src/main/java/com/fourweekdays/fourweekdays/asn/service/AsnService.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/asn/service/AsnService.java
@@ -59,7 +59,9 @@ public class AsnService {
         asnRepository.save(asn);
 
         // inbound 자동 생성
-        inboundService.createByPurchaseOrder(purchaseOrder);
+        purchaseOrder.awaitDelivery(); // 배송대기 상태로 변경
+        inboundService.createByPurchaseOrder(purchaseOrder); // 발주서에 따른 입고서 생성
+
 
         return AsnReceiveResponse.builder()
                 .asnCode(asn.getAsnCode())

--- a/src/main/java/com/fourweekdays/fourweekdays/asn/service/AsnService.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/asn/service/AsnService.java
@@ -59,7 +59,7 @@ public class AsnService {
         asnRepository.save(asn);
 
         // inbound 자동 생성
-//        Long inboundId = inboundService.createByPurchaseOrder(purchaseOrder);
+        inboundService.createByPurchaseOrder(purchaseOrder);
 
         return AsnReceiveResponse.builder()
                 .asnCode(asn.getAsnCode())
@@ -77,7 +77,7 @@ public class AsnService {
             throw new ASNException(VENDOR_MISMATCH);
         }
 
-        if (purchaseOrder.getStatus() != APPROVED && purchaseOrder.getStatus() != AWAITING_DELIVERY) {
+        if (purchaseOrder.getStatus() != APPROVED) {
             throw new PurchaseOrderException(PURCHASE_ORDER_CANNOT_REJECT);
         }
 

--- a/src/main/java/com/fourweekdays/fourweekdays/asn/service/AsnService.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/asn/service/AsnService.java
@@ -1,19 +1,16 @@
 package com.fourweekdays.fourweekdays.asn.service;
 
 import com.fourweekdays.fourweekdays.asn.exception.ASNException;
-import com.fourweekdays.fourweekdays.asn.exception.ASNExceptionType;
 import com.fourweekdays.fourweekdays.asn.model.dto.request.PurchaseOrderRejectRequest;
-import com.fourweekdays.fourweekdays.asn.model.dto.response.ASNResponse;
+import com.fourweekdays.fourweekdays.asn.model.dto.response.AsnResponse;
 import com.fourweekdays.fourweekdays.asn.model.dto.request.AsnReceiveRequest;
 import com.fourweekdays.fourweekdays.asn.model.dto.response.AsnReceiveResponse;
-import com.fourweekdays.fourweekdays.asn.model.entity.ASN;
-import com.fourweekdays.fourweekdays.asn.repository.ASNRepository;
+import com.fourweekdays.fourweekdays.asn.model.entity.Asn;
+import com.fourweekdays.fourweekdays.asn.repository.AsnRepository;
 import com.fourweekdays.fourweekdays.common.generator.CodeGenerator;
 import com.fourweekdays.fourweekdays.inbound.service.InboundService;
 import com.fourweekdays.fourweekdays.purchaseorder.exception.PurchaseOrderException;
-import com.fourweekdays.fourweekdays.purchaseorder.exception.PurchaseOrderExceptionType;
 import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrder;
-import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrderStatus;
 import com.fourweekdays.fourweekdays.purchaseorder.repository.PurchaseOrderRepository;
 import com.fourweekdays.fourweekdays.vendor.model.entity.Vendor;
 import lombok.RequiredArgsConstructor;
@@ -37,7 +34,7 @@ public class AsnService {
 
     private final String ASN_CODE_PREFIX = "ASN";
 
-    private final ASNRepository asnRepository;
+    private final AsnRepository asnRepository;
     private final PurchaseOrderRepository purchaseOrderRepository;
     private final InboundService inboundService;
     private final CodeGenerator codeGenerator;
@@ -52,7 +49,7 @@ public class AsnService {
             throw new ASNException(VENDOR_MISMATCH);
         }
 
-        ASN asn = ASN.create(
+        Asn asn = Asn.create(
                 vendor,
                 purchaseOrder,
                 codeGenerator.generate(ASN_CODE_PREFIX),
@@ -87,15 +84,15 @@ public class AsnService {
         purchaseOrder.rejectByVendor(request.description());
     }
 
-    public ASNResponse asnDetail(Long asnId) {
-        ASN asn = asnRepository.findById(asnId)
+    public AsnResponse asnDetail(Long asnId) {
+        Asn asn = asnRepository.findById(asnId)
                 .orElseThrow(() -> new ASNException(ASN_NOT_FOUND));
-        return ASNResponse.toDto(asn);
+        return AsnResponse.toDto(asn);
     }
 
-    public Page<ASNResponse> asnListByPaging(int page, int size) {
+    public Page<AsnResponse> asnListByPaging(int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<ASN> pageList = asnRepository.findAllWithPaging(pageable);
-        return pageList.map(ASNResponse::toDto);
+        Page<Asn> pageList = asnRepository.findAllWithPaging(pageable);
+        return pageList.map(AsnResponse::toDto);
     }
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/exception/PurchaseOrderExceptionType.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/exception/PurchaseOrderExceptionType.java
@@ -3,10 +3,11 @@ package com.fourweekdays.fourweekdays.purchaseorder.exception;
 import com.fourweekdays.fourweekdays.global.exception.ExceptionType;
 import org.springframework.http.HttpStatus;
 
-import static org.springframework.http.HttpStatus.CONFLICT;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.*;
 
 public enum PurchaseOrderExceptionType implements ExceptionType {
+
+    PURCHASE_ORDER_CANNOT_REJECT(BAD_REQUEST, "현재 상태에서는 거절할 수 없습니다"),
 
     PURCHASE_ORDER_NOT_FOUND(NOT_FOUND, "해당 발주서를 찾을 수 없습니다."),
 

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/entity/PurchaseOrder.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/entity/PurchaseOrder.java
@@ -46,6 +46,9 @@ public class PurchaseOrder extends BaseEntity {
 //    @Column(length = 100)
 //    private String orderedBy; // 발주 담당자
 
+    private String rejectedReason;  // nullable
+    private LocalDateTime rejectedAt;  // nullable
+
     // ===== 연관관계 편의 메서드 ===== //
     public void addItem(PurchaseOrderProduct purchaseOrderProduct) {
         this.items.add(purchaseOrderProduct);
@@ -74,6 +77,12 @@ public class PurchaseOrder extends BaseEntity {
     }
 
     public void cancel() {
+        this.status = PurchaseOrderStatus.CANCELLED;
+    }
+
+    public void rejectByVendor(String reason) {
+        this.rejectedReason = reason;
+        this.rejectedAt = LocalDateTime.now();
         this.status = PurchaseOrderStatus.CANCELLED;
     }
     // ... 발주 승인 메서드 ...

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/entity/PurchaseOrder.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/entity/PurchaseOrder.java
@@ -76,6 +76,10 @@ public class PurchaseOrder extends BaseEntity {
         this.status = PurchaseOrderStatus.APPROVED;
     }
 
+    public void awaitDelivery() {
+        this.status = PurchaseOrderStatus.AWAITING_DELIVERY;
+    }
+
     public void cancel() {
         this.status = PurchaseOrderStatus.CANCELLED;
     }
@@ -85,8 +89,6 @@ public class PurchaseOrder extends BaseEntity {
         this.rejectedAt = LocalDateTime.now();
         this.status = PurchaseOrderStatus.CANCELLED;
     }
-    // ... 발주 승인 메서드 ...
-    // ... 발주 확정 메서드 ...
+
     // ... 입고 완료 처리 메서드 ...
-    // ... 발주 취소 메서드 ...
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/entity/PurchaseOrderStatus.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/entity/PurchaseOrderStatus.java
@@ -7,8 +7,8 @@ public enum PurchaseOrderStatus {
 
     REQUESTED("발주 요청"), // 승인 대기
     APPROVED("승인 완료"), // 승인됨 (공급사로 발주 전송)
-    AWAITING_DELIVERY("납품 대기"), // 공급사 납품(ASN) 대기
-    DELIVERED("도착 예정"), // ASN 수신 완료 → Inbound 생성 완료
+    AWAITING_DELIVERY("납품 대기"), // 공급사 납품 대기 (ASN 수신)
+    COMPLETED("배송 완료"),
     CANCELLED("취소"); // 취소됨
 
     private final String status;


### PR DESCRIPTION
# 🧩 Issue
- #140 

## 📝 요약
- 상태에 따른 입고서 생성을 구현하고 Asn 수신 입고서 생성 조건 변경한다..

## 🔍 변경 사항
- 입고서 생성 조건을 Asn 수신 이후에는 취소 되지 않게 수정했습니다. 
```Java
    @Transactional
    public void rejectPurchaseOrderByVendor(Vendor vendor, PurchaseOrderRejectRequest request) {
       // ... 조회 및 검증 ... //

        if (purchaseOrder.getStatus() != APPROVED) { // <<<<<<< 여기 조건 변경
            throw new PurchaseOrderException(PURCHASE_ORDER_CANNOT_REJECT);
        }

       // ... 발주를 취소 ... //
    }
```
- close #140 

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수 했는가?
- [x] 커밋 내용에 시크릿 키 등의 공유되지 말아야 할 것들을 제거 했는가?

## 💬 기타 공유사항
1. 발주서에 따른 입고서 자동생성
```Java
    @Transactional
    public AsnReceiveResponse receiveAsn(Vendor vendor, AsnReceiveRequest request) {
       // ... 조회 ... //
       // ... asn 생성... //

        // inbound 자동 생성
        purchaseOrder.awaitDelivery(); // 배송대기 상태로 변경
        inboundService.createByPurchaseOrder(purchaseOrder); // 발주서에 따른 입고서 생성
       // ... 응답 ... //
    }
```