### PR TITLE
feat:게시글 작성시 작성자 이름으로 저장되는 기능 추가 & 게시글 삭제 시 비활성화로 바뀌는 기능 추가

### DIFF
--- a/src/main/java/com/fourweekdays/fourweekdays/announcement/controller/AnnouncementController.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/announcement/controller/AnnouncementController.java
@@ -5,9 +5,12 @@ import com.fourweekdays.fourweekdays.announcement.model.dto.request.Announcement
 import com.fourweekdays.fourweekdays.announcement.model.dto.response.AnnouncementReadDto;
 import com.fourweekdays.fourweekdays.announcement.service.AnnouncementService;
 import com.fourweekdays.fourweekdays.common.BaseResponse;
+import com.fourweekdays.fourweekdays.member.model.UserAuth;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -19,7 +22,10 @@ public class AnnouncementController {
 
     @PostMapping
     public ResponseEntity<BaseResponse<Long>> announcementCreate(@RequestBody AnnouncementCreateDto dto) {
-        Long result = announcementService.create(dto);
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        UserAuth userAuth = (UserAuth) authentication.getPrincipal();
+        String name = userAuth.getName();
+        Long result = announcementService.create(dto, name);
         return ResponseEntity.ok(BaseResponse.success(result));
     }
 

--- a/src/main/java/com/fourweekdays/fourweekdays/announcement/controller/AnnouncementController.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/announcement/controller/AnnouncementController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,9 +22,8 @@ public class AnnouncementController {
     private final AnnouncementService announcementService;
 
     @PostMapping
-    public ResponseEntity<BaseResponse<Long>> announcementCreate(@RequestBody AnnouncementCreateDto dto) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        UserAuth userAuth = (UserAuth) authentication.getPrincipal();
+    public ResponseEntity<BaseResponse<Long>> announcementCreate(@RequestBody AnnouncementCreateDto dto,
+                                                                 @AuthenticationPrincipal UserAuth userAuth) {
         String name = userAuth.getName();
         Long result = announcementService.create(dto, name);
         return ResponseEntity.ok(BaseResponse.success(result));

--- a/src/main/java/com/fourweekdays/fourweekdays/announcement/model/dto/request/AnnouncementCreateDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/announcement/model/dto/request/AnnouncementCreateDto.java
@@ -11,8 +11,9 @@ public class AnnouncementCreateDto {
     private String title;
     private String content;
 
-    public Announcement toEntity() {
+    public Announcement toEntity(String name) {
         return Announcement.builder()
+                .name(name)
                 .title(title)
                 .content(content)
                 .build();

--- a/src/main/java/com/fourweekdays/fourweekdays/announcement/model/dto/response/AnnouncementReadDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/announcement/model/dto/response/AnnouncementReadDto.java
@@ -5,18 +5,26 @@ import com.fourweekdays.fourweekdays.announcement.model.entity.Announcement;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Builder
 public class AnnouncementReadDto {
     private Long id;
+    private String name;
     private String title;
     private String content;
+    private boolean active;
+    private LocalDateTime createdAt;
 
     public static AnnouncementReadDto from(Announcement entity) {
         return AnnouncementReadDto.builder()
                 .id(entity.getId())
+                .name(entity.getName())
                 .title(entity.getTitle())
                 .content(entity.getContent())
+                .active(Boolean.TRUE.equals(entity.getActive()))
+                .createdAt(entity.getCreatedAt())
                 .build();
     };
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/announcement/model/entity/Announcement.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/announcement/model/entity/Announcement.java
@@ -19,6 +19,9 @@ public class Announcement extends BaseEntity {
     private Long id;
 
     @Column(nullable = false)
+    private String name; // 이름
+
+    @Column(nullable = false)
     private String title; // 제목
 
     @Column(nullable = false)

--- a/src/main/java/com/fourweekdays/fourweekdays/announcement/service/AnnouncementService.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/announcement/service/AnnouncementService.java
@@ -21,8 +21,8 @@ public class AnnouncementService {
 
     private final AnnouncementRepository announcementRepository;
 
-    public Long create(AnnouncementCreateDto dto) {
-        Announcement result = announcementRepository.save(dto.toEntity());
+    public Long create(AnnouncementCreateDto dto ,String name) {
+        Announcement result = announcementRepository.save(dto.toEntity(name));
         return result.getId();
     }
 

--- a/src/main/java/com/fourweekdays/fourweekdays/member/config/filter/JwtAuthFilter.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/member/config/filter/JwtAuthFilter.java
@@ -54,11 +54,13 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
                     String email = JwtUtil.getValue(claims, JwtUtil.EMAIL_NAME);
                     Long id = Long.parseLong(JwtUtil.getValue(claims, JwtUtil.IDX_NAME));
+                    String name = JwtUtil.getValue(claims, JwtUtil.NAME_NAME);
                     String role = JwtUtil.getValue(claims, JwtUtil.ROLE_NAME);
 
                     UserAuth authUser = UserAuth.builder()
                             .id(id)
                             .email(email)
+                            .name(name)
                             .build();
 
                     // Authentication 객체 생성


### PR DESCRIPTION
# 🧩 Issue

## 📝 요약
게시글 작성시 작성자 이름으로 저장되는 기능 추가 & 게시글 삭제 시 비활성화로 바뀌는 기능 추가

## 🔍 변경 사항
-jwt 토큰에 이름정보 안담겨 있어서 담도록 추가했고 게시글 작성할 때 authuser에서 이름가져와서 게시자 이름저장되게 했습니다.

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수 했는가?
- [ ] 커밋 내용에 시크릿 키 등의 공유되지 말아야 할 것들을 제거 했는가?

## 💬 기타 공유사항
그 중요 리뷰는 맨위로 뜨게하는 것도 넣을까 생각 중 & 여기에서도 사진같은 파일 첨부기능 있어야 하나 고민중 의견 부탁드립니다.