### PR TITLE
fix: 발주 엔티티 깨짐 수정하고 변수 명을 변경한다.

### DIFF
--- a/src/main/java/com/fourweekdays/fourweekdays/asn/model/dto/response/AsnResponse.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/asn/model/dto/response/AsnResponse.java
@@ -28,7 +28,7 @@ public class AsnResponse {
                 .vendorName(asn.getVendor().getName())
                 .expectedDate(asn.getExpectedDate())
                 .description(asn.getDescription())
-                .products(purchaseOrder.getItems().stream()
+                .products(purchaseOrder.getProducts().stream()
                         .map(PurchaseOrderProductResponseDto::toDto)
                         .toList())
                 .build();

--- a/src/main/java/com/fourweekdays/fourweekdays/config/InitialDataSetup.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/config/InitialDataSetup.java
@@ -448,7 +448,7 @@ public class InitialDataSetup {
                     .expectedDate(LocalDateTime.now().plusDays(3))
                     .status(PurchaseOrderStatus.APPROVED)
                     .description("설화수, 라네즈 정기 발주")
-                    .items(new ArrayList<>())
+                    .products(new ArrayList<>())
                     .build();
 
             PurchaseOrderProduct po1Item1 = PurchaseOrderProduct.builder()
@@ -479,10 +479,10 @@ public class InitialDataSetup {
                     .description("인기 상품")
                     .build();
 
-            po1.getItems().add(po1Item1);
-            po1.getItems().add(po1Item2);
-            po1.getItems().add(po1Item3);
-            po1.getItems().add(po1Item4);
+            po1.getProducts().add(po1Item1);
+            po1.getProducts().add(po1Item2);
+            po1.getProducts().add(po1Item3);
+            po1.getProducts().add(po1Item4);
             purchaseOrderRepository.save(po1);
 
             // 발주 2: LG생활건강 제품 발주
@@ -493,7 +493,7 @@ public class InitialDataSetup {
                     .expectedDate(LocalDateTime.now().plusDays(7))
                     .status(PurchaseOrderStatus.REQUESTED)
                     .description("더페이스샵, 빌리프 신규 입고")
-                    .items(new ArrayList<>())
+                    .products(new ArrayList<>())
                     .build();
 
             PurchaseOrderProduct po2Item1 = PurchaseOrderProduct.builder()
@@ -517,9 +517,9 @@ public class InitialDataSetup {
                     .description("고급 라인")
                     .build();
 
-            po2.getItems().add(po2Item1);
-            po2.getItems().add(po2Item2);
-            po2.getItems().add(po2Item3);
+            po2.getProducts().add(po2Item1);
+            po2.getProducts().add(po2Item2);
+            po2.getProducts().add(po2Item3);
             purchaseOrderRepository.save(po2);
 
             // 발주 3: 코스맥스 ODM 제품 발주
@@ -530,7 +530,7 @@ public class InitialDataSetup {
                     .expectedDate(LocalDateTime.now().plusDays(10))
                     .status(PurchaseOrderStatus.APPROVED)
                     .description("기능성 화장품 긴급 발주")
-                    .items(new ArrayList<>())
+                    .products(new ArrayList<>())
                     .build();
 
             PurchaseOrderProduct po3Item1 = PurchaseOrderProduct.builder()
@@ -547,8 +547,8 @@ public class InitialDataSetup {
                     .description("주름개선")
                     .build();
 
-            po3.getItems().add(po3Item1);
-            po3.getItems().add(po3Item2);
+            po3.getProducts().add(po3Item1);
+            po3.getProducts().add(po3Item2);
             purchaseOrderRepository.save(po3);
 
             // 발주 4: 미샤 제품 발주
@@ -559,7 +559,7 @@ public class InitialDataSetup {
                     .expectedDate(LocalDateTime.now().plusDays(5))
                     .status(PurchaseOrderStatus.APPROVED)
                     .description("미샤 인기 제품 재입고")
-                    .items(new ArrayList<>())
+                    .products(new ArrayList<>())
                     .build();
 
             PurchaseOrderProduct po4Item1 = PurchaseOrderProduct.builder()
@@ -583,9 +583,9 @@ public class InitialDataSetup {
                     .description("고가 라인")
                     .build();
 
-            po4.getItems().add(po4Item1);
-            po4.getItems().add(po4Item2);
-            po4.getItems().add(po4Item3);
+            po4.getProducts().add(po4Item1);
+            po4.getProducts().add(po4Item2);
+            po4.getProducts().add(po4Item3);
             purchaseOrderRepository.save(po4);
 
             // 발주 5: 토니모리 색조 제품 발주
@@ -596,7 +596,7 @@ public class InitialDataSetup {
                     .expectedDate(LocalDateTime.now().plusDays(12))
                     .status(PurchaseOrderStatus.REQUESTED)
                     .description("색조 화장품 대량 발주")
-                    .items(new ArrayList<>())
+                    .products(new ArrayList<>())
                     .build();
 
             PurchaseOrderProduct po5Item1 = PurchaseOrderProduct.builder()
@@ -620,9 +620,9 @@ public class InitialDataSetup {
                     .description("롱래쉬")
                     .build();
 
-            po5.getItems().add(po5Item1);
-            po5.getItems().add(po5Item2);
-            po5.getItems().add(po5Item3);
+            po5.getProducts().add(po5Item1);
+            po5.getProducts().add(po5Item2);
+            po5.getProducts().add(po5Item3);
             purchaseOrderRepository.save(po5);
 
             log.info("✓ 발주 5건 생성");

--- a/src/main/java/com/fourweekdays/fourweekdays/inbound/service/InboundService.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/inbound/service/InboundService.java
@@ -68,7 +68,7 @@ public class InboundService {
                 .scheduledDate(purchaseOrder.getExpectedDate())
                 .build();
 
-        purchaseOrder.getItems().forEach(purchaseOrderProduct -> {
+        purchaseOrder.getProducts().forEach(purchaseOrderProduct -> {
             InboundProduct.builder()
                     .inbound(inbound)
                     .product(purchaseOrderProduct.getProduct())
@@ -190,7 +190,7 @@ public class InboundService {
         PurchaseOrder purchaseOrder = purchaseOrderRepository.findById(requestDto.getPurchaseOrderId())
                 .orElseThrow(() -> new PurchaseOrderException(PURCHASE_ORDER_NOT_FOUND));
 
-        purchaseOrder.getItems().forEach(poItem -> {
+        purchaseOrder.getProducts().forEach(poItem -> {
             InboundProduct inboundItem = InboundProduct.builder()
                     .product(poItem.getProduct())
                     .purchaseOrderProduct(poItem)

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/response/PurchaseOrderReadDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/dto/response/PurchaseOrderReadDto.java
@@ -35,7 +35,7 @@ public class PurchaseOrderReadDto {
                 .status(entity.getStatus())
                 .totalAmount(entity.calculateTotalAmount())
                 .description(entity.getDescription())
-                .items(entity.getItems().stream()
+                .items(entity.getProducts().stream()
                         .map(PurchaseOrderProductResponseDto::toDto)
                         .toList())
                 .build();

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/entity/PurchaseOrderProduct.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/model/entity/PurchaseOrderProduct.java
@@ -40,6 +40,7 @@ public class PurchaseOrderProduct extends BaseEntity {
     public Long calculateAmount() {
         return this.product.getUnitPrice() * orderedQuantity;
     }
+
     // ... 입고 진행률 조회 메서드 (Inbound에서 집계) ...
 }
 

--- a/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/service/PurchaseOrderService.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/purchaseorder/service/PurchaseOrderService.java
@@ -83,34 +83,6 @@ public class PurchaseOrderService {
         return order.getId();
     }
 
-    // 발주 승인
-    @Transactional
-    public Long approve(Long id) {
-        PurchaseOrder order = findByIdOrThrow(id);
-        order.approve(); // 상태 변경
-        return inboundService.createByPurchaseOrder(order); // 입고 자동 생성
-    }
-
-    // 발주 확정 (공급사 납품 준비 완료)
-    @Transactional
-    public void confirm(Long id) {
-        PurchaseOrder order = findByIdOrThrow(id);
-        if (order.getStatus() != PurchaseOrderStatus.APPROVED) {
-            throw new PurchaseOrderException(PURCHASE_ORDER_INVALID_STATUS_CHANGE);
-        }
-        order.confirm();
-    }
-
-    // 입고 완료 처리
-    @Transactional
-    public void completeInbound(Long id) {
-        PurchaseOrder order = findByIdOrThrow(id);
-        if (order.getStatus() != PurchaseOrderStatus.AWAITING_DELIVERY) {
-            throw new PurchaseOrderException(PURCHASE_ORDER_INVALID_STATUS_CHANGE);
-        }
-        order.completeInbound();
-    }
-
     // 발주 취소
     @Transactional
     public void cancel(Long id) {
@@ -120,6 +92,34 @@ public class PurchaseOrderService {
         }
         order.cancel();
     }
+
+    // 발주 승인
+    @Transactional
+    public Long approve(Long id) {
+        PurchaseOrder order = findByIdOrThrow(id);
+        order.approve(); // 상태 변경
+        return inboundService.createByPurchaseOrder(order); // 입고 자동 생성
+    }
+
+    @Transactional
+    public void confirm(Long id) {
+        PurchaseOrder order = findByIdOrThrow(id);
+        if (order.getStatus() != PurchaseOrderStatus.APPROVED) {
+            throw new PurchaseOrderException(PURCHASE_ORDER_INVALID_STATUS_CHANGE);
+        }
+        order.awaitDelivery();
+    }
+
+    // 입고 완료 처리
+    @Transactional
+    public void completeInbound(Long id) {
+        PurchaseOrder order = findByIdOrThrow(id);
+        if (order.getStatus() != PurchaseOrderStatus.AWAITING_DELIVERY) {
+            throw new PurchaseOrderException(PURCHASE_ORDER_INVALID_STATUS_CHANGE);
+        }
+        order.completeDelivery();
+    }
+
 
     private PurchaseOrder findByIdOrThrow(Long id) {
         return purchaseOrderRepository.findById(id)


### PR DESCRIPTION
# 🧩 Issue
- #146 

## 📝 요약
버그 픽스

## 🔍 변경 사항
- items -> products 변수 명 변경 << 이거 다른 곳에서  확인되면 말씀해주세요. product로 통일 하는게 나을듯
- #146 

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수 했는가?
- [x] 커밋 내용에 시크릿 키 등의 공유되지 말아야 할 것들을 제거 했는가?

## 💬 기타 공유사항
1. 발주서 상 totalAmount는 로직으로 빼서 dto 나갈 때, 계산하는걸로 필드 빼놨었는데 다시 들어와 있더라구요? 그냥 넣어둘까요?
2. removeItem()은 현재 코드상으로는 있지만 update시 발주서 변경을 어떻게 구현하는가에 따라 다를 것 같습니다. 
발주서 수정시 상품이 부분 변경되는 경우에 대해서 생각 하신 것 같은데 제 생각에는 전체 교체가 더 나을 것 같다는 생각이 들어서요.
```Java 
    // PurchaseOrder.class
    public void removeItem(PurchaseOrderProduct item) {
        this.products.remove(item);
        recalculateTotalAmount();
    }

```