### PR TITLE
feat: singupDto에 검증 로직 추가

### DIFF
--- a/src/main/java/com/fourweekdays/fourweekdays/member/controller/MemberController.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import com.fourweekdays.fourweekdays.member.model.dto.MemberResponseDto;
 import com.fourweekdays.fourweekdays.member.model.dto.MemberSignUpDto;
 import com.fourweekdays.fourweekdays.member.model.dto.MemberUpdateDto;
 import com.fourweekdays.fourweekdays.member.service.MemberService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
@@ -22,7 +23,7 @@ public class MemberController {
 
     // 회원 등록
     @PostMapping("/signup")
-    public ResponseEntity<BaseResponse<String>> register(@RequestBody MemberSignUpDto dto) {
+    public ResponseEntity<BaseResponse<String>> register(@Valid @RequestBody MemberSignUpDto dto) {
         memberService.register(dto);
         return ResponseEntity.ok(BaseResponse.success("등록 완료"));
     }

--- a/src/main/java/com/fourweekdays/fourweekdays/member/model/dto/MemberSignUpDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/member/model/dto/MemberSignUpDto.java
@@ -5,6 +5,7 @@ import com.fourweekdays.fourweekdays.member.model.entity.Member;
 import com.fourweekdays.fourweekdays.member.model.entity.MemberRole;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,19 +20,25 @@ import java.time.LocalDateTime;
 public class MemberSignUpDto {
 
     @NotBlank(message = "이메일 입력을 해주세요")
+    @Pattern(regexp = "^[a-zA-Z0-9+-._]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$", message = "이메일 형식이 올바르지 않습니다.")
     private String email;
 
     @NotBlank(message = "비밀번호을 입력해 주세요")
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d).{8,}$", message = "비밀번호는 영문과 숫자를 포함하여 8자 이상이어야 합니다.")
     private String password;
 
     @NotBlank(message = "이름을 입력해주세요")
     private String name;
 
     @NotBlank(message = "핸드폰번호를 입력해 주세요")
+    @Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "핸드폰번호 형식이 올바르지 않습니다.")
     private String phoneNumber;
 
-    @NotNull(message = "권한을 선택해 주세요")
+    @NotNull(message = "권한을 선택해주세요")
     private MemberRole role;
+
+    @NotNull(message = "상태를 선택해주세요")
+    private AuthStatus status;
 
     //엔티티 변환
     public Member toEntity(String encodedPassword) {
@@ -41,7 +48,7 @@ public class MemberSignUpDto {
                 .name(name)
                 .phoneNumber(phoneNumber)
                 .role(role)
-                .status(AuthStatus.ACTIVE)
+                .status(status)
                 .joinAt(LocalDateTime.now())
                 .build();
     }


### PR DESCRIPTION
# 🧩 Issue
#157 
## 📝 요약
sinupDto 에 입력 양식 검증 추가

## 🔍 변경 사항
- SingUpDto에 이메일 비밀번호 핸드폰 번호 입력 양식 추가
- 양식 추가 검증으로 회원등록 컨트롤러에 @Valid 추가했습니다.


## ✅ 체크리스트
- [x] 코드 컨벤션을 준수 했는가?
- [x] 커밋 내용에 시크릿 키 등의 공유되지 말아야 할 것들을 제거 했는가?

## 💬 기타 공유사항
리뷰어에게 전달할 추가 맥락이나 참고사항