### PR TITLE
Feat/outbound create lhs

### DIFF
--- a/src/main/java/com/fourweekdays/fourweekdays/order/exception/OrderExceptionType.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/order/exception/OrderExceptionType.java
@@ -11,6 +11,7 @@ public enum OrderExceptionType implements ExceptionType {
     ORDER_NOT_FOUND(NOT_FOUND, "해당 주문을 찾을 수 없습니다."),
     FRANCHISE_MISMATCH(BAD_REQUEST, "주문의 거래처가 일치하지 않습니다."),
     ORDER_CANNOT_REJECT(BAD_REQUEST, "현제 상태에서는 거절할 수 없습니다."),
+    ORDER_CANNOT_APPROVED(BAD_REQUEST, "현제 상태에서는 출고서를 요청할수 없습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/exception/OutboundException.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/exception/OutboundException.java
@@ -1,0 +1,10 @@
+package com.fourweekdays.fourweekdays.outbound.exception;
+
+import com.fourweekdays.fourweekdays.global.exception.BaseException;
+import com.fourweekdays.fourweekdays.global.exception.ExceptionType;
+
+public class OutboundException extends BaseException {
+    public OutboundException(ExceptionType exceptionType) {
+        super(exceptionType);
+    }
+}

--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/exception/OutboundExceptionType.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/exception/OutboundExceptionType.java
@@ -1,0 +1,36 @@
+package com.fourweekdays.fourweekdays.outbound.exception;
+
+import com.fourweekdays.fourweekdays.global.exception.ExceptionType;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+public enum OutboundExceptionType implements ExceptionType {
+
+    OUTBOUND_STATUS_TRANSITION_NOT_ALLOWED(BAD_REQUEST, "출고 상태를 변경할 수 없습니다."),
+    OUTBOUND_INVALID_STATUS_FOR_INSPECTION(BAD_REQUEST, "검수 작업을 할 수 없는 상태입니다."),
+    OUTBOUND_CANNOT_CANCEL(BAD_REQUEST, "출고를 취소할 수 없습니다." ),
+
+    OUTBOUND_NOT_FOUND(NOT_FOUND, "해당 출고를 찾을 수 없습니다."),
+    OUTBOUND_PRODUCT_NOT_FOUND(NOT_FOUND, "출고 상품을 찾을 수 없습니다."), ;
+
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    OutboundExceptionType(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus statusCode() {
+        return this.httpStatus;
+    }
+
+    @Override
+    public String message() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/exception/OutboundExceptionType.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/exception/OutboundExceptionType.java
@@ -13,7 +13,10 @@ public enum OutboundExceptionType implements ExceptionType {
     OUTBOUND_CANNOT_CANCEL(BAD_REQUEST, "출고를 취소할 수 없습니다." ),
 
     OUTBOUND_NOT_FOUND(NOT_FOUND, "해당 출고를 찾을 수 없습니다."),
-    OUTBOUND_PRODUCT_NOT_FOUND(NOT_FOUND, "출고 상품을 찾을 수 없습니다."), ;
+    OUTBOUND_PRODUCT_NOT_FOUND(NOT_FOUND, "출고 상품을 찾을 수 없습니다."),
+
+    OUTBOUND_ORDER_EXISTENCE (BAD_REQUEST, "중복된 출고 요청."),
+    ;
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/model/dto/request/OutboundCreateDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/model/dto/request/OutboundCreateDto.java
@@ -24,7 +24,7 @@ public class OutboundCreateDto {
 
     public Outbound toEntity(String outboundCode, OutboundStatus status) {
         return Outbound.builder()
-                .member(Member.builder().id(memberId).build())
+                .outboundManager(Member.builder().id(memberId).build())
                 .order(Order.builder().orderId(orderId).build())
                 .scheduledDate(scheduledDate)
                 .description(description)

--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/model/dto/request/OutboundCreateDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/model/dto/request/OutboundCreateDto.java
@@ -18,9 +18,9 @@ public class OutboundCreateDto {
 
     private Long memberId;
     private Long orderId;
-//     private List<InboundProductDto> items; // 직접/추가
     private LocalDateTime scheduledDate; // 출고 예상 시간
     private String description;
+//     private List<InboundProductDto> items; // 직접/추가
 
     public Outbound toEntity(String outboundCode, OutboundStatus status) {
         return Outbound.builder()

--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/model/dto/request/OutboundCreateDto.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/model/dto/request/OutboundCreateDto.java
@@ -1,20 +1,35 @@
 package com.fourweekdays.fourweekdays.outbound.model.dto.request;
 
+import com.fourweekdays.fourweekdays.inbound.model.dto.request.InboundProductDto;
+import com.fourweekdays.fourweekdays.member.model.entity.Member;
+import com.fourweekdays.fourweekdays.order.model.entity.Order;
 import com.fourweekdays.fourweekdays.outbound.model.entity.Outbound;
 import com.fourweekdays.fourweekdays.outbound.model.entity.OutboundStatus;
 import com.fourweekdays.fourweekdays.outbound.model.entity.OutboundType;
+import lombok.Builder;
 import lombok.Getter;
 
-@Getter
-public class OutboundCreateDto {
-    private int quantity;
-    private OutboundType outboundType;
+import java.time.LocalDateTime;
+import java.util.List;
 
-    public Outbound toEntity() {
+@Getter
+@Builder
+public class OutboundCreateDto {
+
+    private Long memberId;
+    private Long orderId;
+//     private List<InboundProductDto> items; // 직접/추가
+    private LocalDateTime scheduledDate; // 출고 예상 시간
+    private String description;
+
+    public Outbound toEntity(String outboundCode, OutboundStatus status) {
         return Outbound.builder()
-//                .quantity(quantity)
-                .outboundType(outboundType)
-                .status(OutboundStatus.PENDING)
+                .member(Member.builder().id(memberId).build())
+                .order(Order.builder().orderId(orderId).build())
+                .scheduledDate(scheduledDate)
+                .description(description)
+                .outboundCode(outboundCode)
+                .status(status)
                 .build();
     }
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/model/entity/Outbound.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/model/entity/Outbound.java
@@ -9,6 +9,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Builder
@@ -21,6 +23,9 @@ public class Outbound extends BaseEntity {
     @Column(name = "outbound_id")
     private Long id; // 출고 ID
 
+    @Column(nullable = false)
+    private String outboundCode;
+
     @Enumerated(EnumType.STRING)
     private OutboundType outboundType; // 출고유형
 
@@ -29,11 +34,15 @@ public class Outbound extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "order_id")
-    private Order order;
+    private Order order; // 주문 기반 출고 생성
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member; // 출고 등록인
+
+    private LocalDateTime scheduledDate; // 출고 예상 일시
+
+    private String description;
     // 출고에 맴버에 대한 연관 관계는 이렇게 생각함 이 문서를 생성한 인원이라고 생각하고 null 허용
     // 작업 부분에서 출고 상세 작업들에 대해 알아서 인원 배정할 것이고
 

--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/model/entity/Outbound.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/model/entity/Outbound.java
@@ -10,6 +10,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -46,8 +48,9 @@ public class Outbound extends BaseEntity {
     // 출고에 맴버에 대한 연관 관계는 이렇게 생각함 이 문서를 생성한 인원이라고 생각하고 null 허용
     // 작업 부분에서 출고 상세 작업들에 대해 알아서 인원 배정할 것이고
 
-//    @OneToMany(fetch = FetchType.LAZY)
-//    private List<OutboundProductItem> items = new ArrayList<>();
+    @Builder.Default
+    @OneToMany(mappedBy = "outbound", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OutboundProductItem> items = new ArrayList<>();
 //
 //    @ManyToOne
 //    @JoinColumn(name = "franchise_store_id")

--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/model/entity/Outbound.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/model/entity/Outbound.java
@@ -1,6 +1,7 @@
 package com.fourweekdays.fourweekdays.outbound.model.entity;
 
 import com.fourweekdays.fourweekdays.common.BaseEntity;
+import com.fourweekdays.fourweekdays.franchise.model.entity.FranchiseStore;
 import com.fourweekdays.fourweekdays.member.model.entity.Member;
 import com.fourweekdays.fourweekdays.order.model.entity.Order;
 import jakarta.persistence.*;
@@ -40,13 +41,11 @@ public class Outbound extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
-    private Member member; // 출고 등록인
+    private Member outboundManager; // 출고 등록인
 
     private LocalDateTime scheduledDate; // 출고 예상 일시
 
     private String description;
-    // 출고에 맴버에 대한 연관 관계는 이렇게 생각함 이 문서를 생성한 인원이라고 생각하고 null 허용
-    // 작업 부분에서 출고 상세 작업들에 대해 알아서 인원 배정할 것이고
 
     @Builder.Default
     @OneToMany(mappedBy = "outbound", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -54,6 +53,9 @@ public class Outbound extends BaseEntity {
 //
 //    @ManyToOne
 //    @JoinColumn(name = "franchise_store_id")
-//    private FranchiseStore store;
-//
+//    private FranchiseStore franchiseStore;
+//    Order 기반 출고를 할 경우 Order와 매핑되어 있을거니까 Franchise_store 받아올수 있고
+//    Order 기반이 아니라면 아예 핑요 없는 경우가 있음
+//    반대로 필요한 경우 Order 없이 franchise로 출고가 발생할 경우
+//    -> 관리자의 상품기반 등록이 필요해짐 + 중복된 Order에 대해서 허용이 가능해야 함
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/model/entity/OutboundProductItem.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/model/entity/OutboundProductItem.java
@@ -29,7 +29,7 @@ public class OutboundProductItem {
     private OrderProductItem orderProductItem;
 
     @Column(nullable = false)
-    private Integer receivedQuantity; // 입고 수량
+    private Integer receivedQuantity; // 주문 수량
 
 //    @Column(length = 50, nullable = true)
 //    private String lotNumber; // 로트번호 이거 상품에 대해 개별적인 추적이 필요할 때만 사용한다고 하네요 우리는 화장품이라 필요 없는것 같아요

--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/model/entity/OutboundProductItem.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/model/entity/OutboundProductItem.java
@@ -37,4 +37,10 @@ public class OutboundProductItem {
 
     @Column(length = 1000)
     private String description; // 비고
+
+    // ===== 연관관계 편의 메서드 ===== //
+    public void assignOutbound(Outbound outbound) {
+        this.outbound = outbound;
+        outbound.getItems().add(this);
+    }
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/repository/OutboundRepository.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/repository/OutboundRepository.java
@@ -1,7 +1,11 @@
 package com.fourweekdays.fourweekdays.outbound.repository;
 
+import com.fourweekdays.fourweekdays.order.model.entity.Order;
 import com.fourweekdays.fourweekdays.outbound.model.entity.Outbound;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface OutboundRepository extends JpaRepository<Outbound, Long> {
+    boolean existsByOrder(Order order);
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/repository/OutboundRepository.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/repository/OutboundRepository.java
@@ -1,0 +1,7 @@
+package com.fourweekdays.fourweekdays.outbound.repository;
+
+import com.fourweekdays.fourweekdays.outbound.model.entity.Outbound;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OutboundRepository extends JpaRepository<Outbound, Long> {
+}

--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/service/OutboundService.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/service/OutboundService.java
@@ -1,21 +1,56 @@
 package com.fourweekdays.fourweekdays.outbound.service;
 
+import com.fourweekdays.fourweekdays.common.generator.CodeGenerator;
+import com.fourweekdays.fourweekdays.member.exception.MemberException;
+import com.fourweekdays.fourweekdays.member.model.entity.Member;
+import com.fourweekdays.fourweekdays.member.repository.MemberRepository;
+import com.fourweekdays.fourweekdays.order.exception.OrderException;
+import com.fourweekdays.fourweekdays.order.model.entity.Order;
+import com.fourweekdays.fourweekdays.order.repository.OrderRepository;
+import com.fourweekdays.fourweekdays.outbound.exception.OutboundException;
 import com.fourweekdays.fourweekdays.outbound.model.dto.request.OutboundCreateDto;
 import com.fourweekdays.fourweekdays.outbound.model.dto.response.OutboundReadDto;
 import com.fourweekdays.fourweekdays.outbound.model.dto.response.OutboundStatusResponse;
+import com.fourweekdays.fourweekdays.outbound.model.entity.Outbound;
+import com.fourweekdays.fourweekdays.outbound.model.entity.OutboundStatus;
+import com.fourweekdays.fourweekdays.outbound.repository.OutboundRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static com.fourweekdays.fourweekdays.member.exception.MemberExceptionType.MEMBER_NOT_FOUND;
+import static com.fourweekdays.fourweekdays.order.exception.OrderExceptionType.ORDER_NOT_FOUND;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class OutboundService {
 
+    private static final String OUTBOUND_CODE_PREFIX = "OB";
+
+    private final MemberRepository memberRepository;
+    private final OutboundRepository outboundRepository;
+    private final CodeGenerator codeGenerator;
+    private final OrderRepository orderRepository;
+
     // 출고 생성
     public Long createOutbound(OutboundCreateDto dto) {
+        Member member = memberRepository.findById(dto.getMemberId())
+                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+
+        Order order = orderRepository.findById(dto.getOrderId())
+                .orElseThrow(() -> new OrderException(ORDER_NOT_FOUND));
+
+        String OutboundCode = codeGenerator.generate(OUTBOUND_CODE_PREFIX);
+        OutboundStatus status = OutboundStatus.PENDING;
+
+        Outbound outbound = dto.toEntity(OutboundCode, status);
+
+//        이러고 아웃바운드 product 만들기\
+
+
         return null;
     }
 

--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/service/OutboundService.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/service/OutboundService.java
@@ -1,19 +1,28 @@
 package com.fourweekdays.fourweekdays.outbound.service;
 
 import com.fourweekdays.fourweekdays.common.generator.CodeGenerator;
+import com.fourweekdays.fourweekdays.inbound.model.dto.request.InboundCreateRequestDto;
+import com.fourweekdays.fourweekdays.inbound.model.entity.Inbound;
+import com.fourweekdays.fourweekdays.inbound.model.entity.InboundProduct;
 import com.fourweekdays.fourweekdays.member.exception.MemberException;
 import com.fourweekdays.fourweekdays.member.model.entity.Member;
 import com.fourweekdays.fourweekdays.member.repository.MemberRepository;
 import com.fourweekdays.fourweekdays.order.exception.OrderException;
 import com.fourweekdays.fourweekdays.order.model.entity.Order;
+import com.fourweekdays.fourweekdays.order.model.entity.OrderStatus;
 import com.fourweekdays.fourweekdays.order.repository.OrderRepository;
 import com.fourweekdays.fourweekdays.outbound.exception.OutboundException;
 import com.fourweekdays.fourweekdays.outbound.model.dto.request.OutboundCreateDto;
 import com.fourweekdays.fourweekdays.outbound.model.dto.response.OutboundReadDto;
 import com.fourweekdays.fourweekdays.outbound.model.dto.response.OutboundStatusResponse;
 import com.fourweekdays.fourweekdays.outbound.model.entity.Outbound;
+import com.fourweekdays.fourweekdays.outbound.model.entity.OutboundProductItem;
 import com.fourweekdays.fourweekdays.outbound.model.entity.OutboundStatus;
 import com.fourweekdays.fourweekdays.outbound.repository.OutboundRepository;
+import com.fourweekdays.fourweekdays.product.exception.ProductException;
+import com.fourweekdays.fourweekdays.product.model.entity.Product;
+import com.fourweekdays.fourweekdays.purchaseorder.exception.PurchaseOrderException;
+import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,7 +30,11 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static com.fourweekdays.fourweekdays.member.exception.MemberExceptionType.MEMBER_NOT_FOUND;
+import static com.fourweekdays.fourweekdays.order.exception.OrderExceptionType.ORDER_CANNOT_APPROVED;
 import static com.fourweekdays.fourweekdays.order.exception.OrderExceptionType.ORDER_NOT_FOUND;
+import static com.fourweekdays.fourweekdays.outbound.exception.OutboundExceptionType.OUTBOUND_ORDER_EXISTENCE;
+import static com.fourweekdays.fourweekdays.product.exception.ProductExceptionType.PRODUCT_NOT_FOUND;
+import static com.fourweekdays.fourweekdays.purchaseorder.exception.PurchaseOrderExceptionType.PURCHASE_ORDER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -36,22 +49,22 @@ public class OutboundService {
     private final OrderRepository orderRepository;
 
     // 출고 생성
+    // 주문과 완전 동일하게 생성되는 시나리오로 진행하겠음
+    @Transactional
     public Long createOutbound(OutboundCreateDto dto) {
-        Member member = memberRepository.findById(dto.getMemberId())
-                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
 
-        Order order = orderRepository.findById(dto.getOrderId())
-                .orElseThrow(() -> new OrderException(ORDER_NOT_FOUND));
+        // member와 order 검증
+        Order order = verification(dto);
 
-        String OutboundCode = codeGenerator.generate(OUTBOUND_CODE_PREFIX);
-        OutboundStatus status = OutboundStatus.PENDING;
+        // Outboun Entity 만들기
+        Outbound outbound = creatBaseOutbound(dto);
 
-        Outbound outbound = dto.toEntity(OutboundCode, status);
+        // order에 상품 목록으로 OutboundProductItems 만들기
+        addItemsFromOrder(outbound, order);
 
-//        이러고 아웃바운드 product 만들기\
+        // TODO addDirectItems x 일단 아이템을 추가로 받지 않게 하겠음
 
-
-        return null;
+        return outboundRepository.save(outbound).getId();
     }
 
     // 출고 승인
@@ -73,4 +86,42 @@ public class OutboundService {
     public OutboundReadDto getOutboundDetails(Long id) {
         return null;
     }
+
+    private Order verification(OutboundCreateDto dto) {
+        Member member = memberRepository.findById(dto.getMemberId())
+                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+
+        Order order = orderRepository.findById(dto.getOrderId())
+                .orElseThrow(() -> new OrderException(ORDER_NOT_FOUND));
+
+        if (!order.getStatus().equals(OrderStatus.APPROVED)) {
+            throw new OrderException(ORDER_CANNOT_APPROVED);
+        }
+
+        if (outboundRepository.existsByOrder(order)) {
+            throw new OutboundException(OUTBOUND_ORDER_EXISTENCE);
+        }
+        return order;
+    }
+
+    private Outbound creatBaseOutbound(OutboundCreateDto dto) {
+        String OutboundCode = codeGenerator.generate(OUTBOUND_CODE_PREFIX);
+        OutboundStatus status = OutboundStatus.PENDING;
+
+        return dto.toEntity(OutboundCode, status);
+    }
+
+    private void addItemsFromOrder(Outbound outbound, Order order) {
+        order.getItems().forEach(poItem -> {
+            OutboundProductItem outboundProductItem = OutboundProductItem.builder()
+                    .product(poItem.getProduct())
+                    .orderProductItem(poItem)
+                    .receivedQuantity(0)
+                    .description(poItem.getDescription())
+                    .build();
+
+            outboundProductItem.assignOutbound(outbound);
+        });
+    }
+
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/service/OutboundService.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/service/OutboundService.java
@@ -57,7 +57,7 @@ public class OutboundService {
         Order order = verification(dto);
 
         // Outboun Entity 만들기
-        Outbound outbound = creatBaseOutbound(dto);
+        Outbound outbound = createBaseOutbound(dto);
 
         // order에 상품 목록으로 OutboundProductItems 만들기
         addItemsFromOrder(outbound, order);
@@ -88,7 +88,7 @@ public class OutboundService {
     }
 
     private Order verification(OutboundCreateDto dto) {
-        Member member = memberRepository.findById(dto.getMemberId())
+        Member manager = memberRepository.findById(dto.getMemberId())
                 .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
 
         Order order = orderRepository.findById(dto.getOrderId())
@@ -104,7 +104,7 @@ public class OutboundService {
         return order;
     }
 
-    private Outbound creatBaseOutbound(OutboundCreateDto dto) {
+    private Outbound createBaseOutbound (OutboundCreateDto dto) {
         String OutboundCode = codeGenerator.generate(OUTBOUND_CODE_PREFIX);
         OutboundStatus status = OutboundStatus.PENDING;
 
@@ -112,12 +112,12 @@ public class OutboundService {
     }
 
     private void addItemsFromOrder(Outbound outbound, Order order) {
-        order.getItems().forEach(poItem -> {
+        order.getItems().forEach(opItem -> {
             OutboundProductItem outboundProductItem = OutboundProductItem.builder()
-                    .product(poItem.getProduct())
-                    .orderProductItem(poItem)
-                    .receivedQuantity(0)
-                    .description(poItem.getDescription())
+                    .product(opItem.getProduct())
+                    .orderProductItem(opItem)
+                    .receivedQuantity(opItem.getOrderedQuantity())
+                    .description(opItem.getDescription())
                     .build();
 
             outboundProductItem.assignOutbound(outbound);


### PR DESCRIPTION
# 🧩 Issue
* #35 
## 📝 요약
outbound 등록 구현

## 🔍 변경 사항
- Feat: Outbound 등록 구현
- Feat: Order를 기준으로 Outbound가 생성되도록 함
- 관련 이슈:  close  #35 

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수 했는가?
- [x] 커밋 내용에 시크릿 키 등의 공유되지 말아야 할 것들을 제거 했는가?

## 💬 기타 공유사항
추가 상품에 대한 기능은 TODO로 대체함
Inbound와 동일하지만 Exception을 모아서 처리하게 했고

order의 상태를 확인하고 APPROVED가 아니라면 생성이 불가능하고
이미 Order로 출고서를 한번 만들었다면 더이상 못 만들게 해놓았습니다.

(실행 테스트 완료)