### PR TITLE
Feat/outbound update lhs

### DIFF
--- a/src/main/java/com/fourweekdays/fourweekdays/order/model/entity/Order.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/order/model/entity/Order.java
@@ -63,4 +63,9 @@ public class Order extends BaseEntity {
         this.rejectedAt = LocalDateTime.now();
         this.status = OrderStatus.CANCELLED;
     }
+
+    // ===== 비즈니스 로직 ===== //
+    public void updateShipped() {
+        this.status = OrderStatus.SHIPPED;
+    }
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/order/model/entity/OrderStatus.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/order/model/entity/OrderStatus.java
@@ -1,5 +1,18 @@
 package com.fourweekdays.fourweekdays.order.model.entity;
 
+import lombok.Getter;
+
+@Getter
 public enum OrderStatus {
-    REQUESTED, APPROVED, SHIPPED, CANCELLED
+    REQUESTED("주문 생성"), // 승인 대기
+    APPROVED("승인 완료"), // 승인됨
+    SHIPPED("출하 완료"), // 출하됨
+    DELIVERED("배송 완료"), // 배송 완료됨
+    CANCELLED("취소"); // 취소됨
+
+    private final String description;
+
+    OrderStatus(String description) {
+        this.description = description;
+    }
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/comtroller/OutboundController.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/comtroller/OutboundController.java
@@ -3,6 +3,7 @@ package com.fourweekdays.fourweekdays.outbound.comtroller;
 import com.fourweekdays.fourweekdays.common.BaseResponse;
 import com.fourweekdays.fourweekdays.common.BaseResponseStatus;
 import com.fourweekdays.fourweekdays.outbound.model.dto.request.OutboundCreateDto;
+import com.fourweekdays.fourweekdays.outbound.model.dto.request.OutboundInspectionRequest;
 import com.fourweekdays.fourweekdays.outbound.model.dto.response.OutboundReadDto;
 import com.fourweekdays.fourweekdays.outbound.model.dto.response.OutboundStatusResponse;
 import com.fourweekdays.fourweekdays.outbound.service.OutboundService;
@@ -27,20 +28,6 @@ public class OutboundController {
         return ResponseEntity.ok(BaseResponse.success(saveId));
     }
 
-    // 출고 승인
-    @PostMapping("/{id}/approve")
-    public ResponseEntity<BaseResponse<OutboundStatusResponse>> approveOutbound(@PathVariable Long id) {
-        OutboundStatusResponse result = outboundService.approveOutbound(id);
-        return ResponseEntity.ok(BaseResponse.success(result));
-    }
-
-    // 출고 거절
-    @PostMapping("/{id}/reject")
-    public ResponseEntity<BaseResponse<OutboundStatusResponse>> rejectOutbound(@PathVariable Long id) {
-        OutboundStatusResponse result = outboundService.rejectOutbound(id);
-        return ResponseEntity.ok(BaseResponse.success(result));
-    }
-
     // 출고서 전체 조회
     @GetMapping
     public ResponseEntity<BaseResponse<List<OutboundReadDto>>> getOutboundList() {
@@ -57,5 +44,26 @@ public class OutboundController {
                     .body(BaseResponse.error(BaseResponseStatus.OUTBOUND_NOT_FOUND));
         }
         return ResponseEntity.ok(BaseResponse.success(outboundDto));
+    }
+
+    // 출고 승인
+    @PatchMapping("/{id}/approve")
+    public ResponseEntity<BaseResponse<String>> approveOutbound(@PathVariable Long id) {
+        outboundService.approveOutbound(id);
+        return ResponseEntity.ok(BaseResponse.success("출고 승인 완료"));
+    }
+
+    // 검수 작업
+    @PatchMapping("/{id}/inspection")
+    public ResponseEntity<BaseResponse<String>> inspectionOutbound(@PathVariable Long id, @RequestBody List<OutboundInspectionRequest> requestList) {
+        outboundService.updateInspection(id, requestList);
+        return ResponseEntity.ok(BaseResponse.success("출고 검수 완료"));
+    }
+
+    // 출고 거절
+    @PatchMapping("/{id}/cancelled")
+    public ResponseEntity<BaseResponse<String>> cancelledOutbound(@PathVariable Long id) {
+        outboundService.cancelledOutbound(id);
+        return ResponseEntity.ok(BaseResponse.success("출고 작업 취소"));
     }
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/model/dto/request/OutboundInspectionRequest.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/model/dto/request/OutboundInspectionRequest.java
@@ -1,0 +1,9 @@
+package com.fourweekdays.fourweekdays.outbound.model.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class OutboundInspectionRequest {
+    private Long OutboundProductid;
+    private Integer orderedQuantity;
+}

--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/model/entity/Outbound.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/model/entity/Outbound.java
@@ -1,9 +1,9 @@
 package com.fourweekdays.fourweekdays.outbound.model.entity;
 
 import com.fourweekdays.fourweekdays.common.BaseEntity;
-import com.fourweekdays.fourweekdays.franchise.model.entity.FranchiseStore;
 import com.fourweekdays.fourweekdays.member.model.entity.Member;
 import com.fourweekdays.fourweekdays.order.model.entity.Order;
+import com.fourweekdays.fourweekdays.outbound.exception.OutboundException;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,6 +13,9 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+
+import static com.fourweekdays.fourweekdays.outbound.exception.OutboundExceptionType.OUTBOUND_STATUS_TRANSITION_NOT_ALLOWED;
 
 @Entity
 @Getter
@@ -50,6 +53,20 @@ public class Outbound extends BaseEntity {
     @Builder.Default
     @OneToMany(mappedBy = "outbound", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OutboundProductItem> items = new ArrayList<>();
+
+    // ===== 입고 상태 변경 메서드 ===== //
+    public void updateStatus(OutboundStatus nextStatus) {
+        if (!this.status.canTransitionTo(nextStatus)) {
+            throw new OutboundException(OUTBOUND_STATUS_TRANSITION_NOT_ALLOWED);
+        }
+        this.status = nextStatus;
+    }
+
+    public Optional<OutboundProductItem> findByItemId(Long outboundProductid) {
+        return items.stream()
+                .filter(item -> item.getId().equals(outboundProductid))
+                .findFirst();
+    }
 //
 //    @ManyToOne
 //    @JoinColumn(name = "franchise_store_id")

--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/model/entity/OutboundProductItem.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/model/entity/OutboundProductItem.java
@@ -29,7 +29,7 @@ public class OutboundProductItem {
     private OrderProductItem orderProductItem;
 
     @Column(nullable = false)
-    private Integer receivedQuantity; // 주문 수량
+    private Integer orderedQuantity; // 주문 수량
 
 //    @Column(length = 50, nullable = true)
 //    private String lotNumber; // 로트번호 이거 상품에 대해 개별적인 추적이 필요할 때만 사용한다고 하네요 우리는 화장품이라 필요 없는것 같아요

--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/model/entity/OutboundProductItem.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/model/entity/OutboundProductItem.java
@@ -43,4 +43,9 @@ public class OutboundProductItem {
         this.outbound = outbound;
         outbound.getItems().add(this);
     }
+
+    // ===== 비즈니스 로직 ===== //
+    public void updateInspectionResult(Integer orderedQuantity) {
+        this.orderedQuantity = orderedQuantity;
+    }
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/model/entity/OutboundStatus.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/model/entity/OutboundStatus.java
@@ -1,7 +1,34 @@
 package com.fourweekdays.fourweekdays.outbound.model.entity;
 
+import lombok.Getter;
+
+@Getter
 public enum OutboundStatus {
-    PENDING,    // 승인 대기
-    APPROVED,   // 승인
-    REJECTED    // 거절
+
+    REQUESTED("출고서 생성"),
+    APPROVED("출고 예정"),
+    PICKING("피킹"),
+    INSPECTION("검수"),
+    PACKING("패킹"),
+    SHIPPED("출하 완료"), // 재고 감소
+    CANCELLED("취소");
+
+    private final String description;
+
+    OutboundStatus(String description) {
+        this.description = description;
+    }
+
+    public boolean canTransitionTo(OutboundStatus next) {
+        if (next == CANCELLED) return true;
+
+        return switch (this) {
+            case REQUESTED -> next == APPROVED;
+            case APPROVED -> next == PICKING;
+            case PICKING -> next == INSPECTION;
+            case INSPECTION -> next == PACKING;
+            case PACKING -> next == SHIPPED;
+            case SHIPPED, CANCELLED -> false;
+        };
+    }
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/service/OutboundService.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/service/OutboundService.java
@@ -1,11 +1,7 @@
 package com.fourweekdays.fourweekdays.outbound.service;
 
 import com.fourweekdays.fourweekdays.common.generator.CodeGenerator;
-import com.fourweekdays.fourweekdays.inbound.model.dto.request.InboundCreateRequestDto;
-import com.fourweekdays.fourweekdays.inbound.model.entity.Inbound;
-import com.fourweekdays.fourweekdays.inbound.model.entity.InboundProduct;
 import com.fourweekdays.fourweekdays.member.exception.MemberException;
-import com.fourweekdays.fourweekdays.member.model.entity.Member;
 import com.fourweekdays.fourweekdays.member.repository.MemberRepository;
 import com.fourweekdays.fourweekdays.order.exception.OrderException;
 import com.fourweekdays.fourweekdays.order.model.entity.Order;
@@ -13,16 +9,12 @@ import com.fourweekdays.fourweekdays.order.model.entity.OrderStatus;
 import com.fourweekdays.fourweekdays.order.repository.OrderRepository;
 import com.fourweekdays.fourweekdays.outbound.exception.OutboundException;
 import com.fourweekdays.fourweekdays.outbound.model.dto.request.OutboundCreateDto;
+import com.fourweekdays.fourweekdays.outbound.model.dto.request.OutboundInspectionRequest;
 import com.fourweekdays.fourweekdays.outbound.model.dto.response.OutboundReadDto;
-import com.fourweekdays.fourweekdays.outbound.model.dto.response.OutboundStatusResponse;
 import com.fourweekdays.fourweekdays.outbound.model.entity.Outbound;
 import com.fourweekdays.fourweekdays.outbound.model.entity.OutboundProductItem;
 import com.fourweekdays.fourweekdays.outbound.model.entity.OutboundStatus;
 import com.fourweekdays.fourweekdays.outbound.repository.OutboundRepository;
-import com.fourweekdays.fourweekdays.product.exception.ProductException;
-import com.fourweekdays.fourweekdays.product.model.entity.Product;
-import com.fourweekdays.fourweekdays.purchaseorder.exception.PurchaseOrderException;
-import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,9 +24,7 @@ import java.util.List;
 import static com.fourweekdays.fourweekdays.member.exception.MemberExceptionType.MEMBER_NOT_FOUND;
 import static com.fourweekdays.fourweekdays.order.exception.OrderExceptionType.ORDER_CANNOT_APPROVED;
 import static com.fourweekdays.fourweekdays.order.exception.OrderExceptionType.ORDER_NOT_FOUND;
-import static com.fourweekdays.fourweekdays.outbound.exception.OutboundExceptionType.OUTBOUND_ORDER_EXISTENCE;
-import static com.fourweekdays.fourweekdays.product.exception.ProductExceptionType.PRODUCT_NOT_FOUND;
-import static com.fourweekdays.fourweekdays.purchaseorder.exception.PurchaseOrderExceptionType.PURCHASE_ORDER_NOT_FOUND;
+import static com.fourweekdays.fourweekdays.outbound.exception.OutboundExceptionType.*;
 
 @Service
 @RequiredArgsConstructor
@@ -68,13 +58,67 @@ public class OutboundService {
     }
 
     // 출고 승인
-    public OutboundStatusResponse approveOutbound(Long id) {
-        return null;
+    @Transactional
+    public void approveOutbound(Long id) {
+        Outbound outbound = chekOutbound(id);
+        outbound.updateStatus(OutboundStatus.APPROVED);
+        // TODO 재고 차감
+        // TODO 출고 작업 생성
     }
 
     // 출고 거절
-    public OutboundStatusResponse rejectOutbound(Long id) {
-        return null;
+    @Transactional
+    public void cancelledOutbound(Long id) {
+        Outbound outbound = chekOutbound(id);
+
+        if (outbound.getStatus() != OutboundStatus.APPROVED && outbound.getStatus() != OutboundStatus.REQUESTED) {
+            throw new OutboundException(OUTBOUND_CANNOT_CANCEL);
+        }
+        outbound.updateStatus(OutboundStatus.CANCELLED);
+        // TODO 재고 차감되었던만큼 증가
+    }
+
+    // TODO task가 작업 착수 -> 피킹중
+    @Transactional
+    public void updatePicking(Long id) {
+        Outbound outbound = chekOutbound(id);
+        outbound.updateStatus(OutboundStatus.PICKING);
+    }
+
+    // TODO task가 피킹 완료 -> 검수중
+    @Transactional
+    public void updatePacking(Long id) {
+        Outbound outbound = chekOutbound(id);
+        outbound.updateStatus(OutboundStatus.INSPECTION);
+    }
+
+    // 검수 완료 작업
+    @Transactional
+    public void updateInspection(Long id, List<OutboundInspectionRequest> requestList) {
+        Outbound outbound = chekOutbound(id);
+
+        if (outbound.getStatus() != OutboundStatus.INSPECTION) {
+            throw new OutboundException(OUTBOUND_INVALID_STATUS_FOR_INSPECTION);
+        }
+
+        for (OutboundInspectionRequest request : requestList) {
+            OutboundProductItem item = outbound.findByItemId(request.getOutboundProductid())
+                    .orElseThrow(() -> new OutboundException(OUTBOUND_PRODUCT_NOT_FOUND));
+            item.updateInspectionResult(request.getOrderedQuantity());
+        }
+
+        // 검수 완료 -> 패킹작업으로 변경
+        outbound.updateStatus(OutboundStatus.PACKING);
+    }
+
+    // TODO 패킹완료 -> 출하
+    @Transactional
+    public void updateShipped(Long id) {
+        Outbound outbound = chekOutbound(id);
+        Order order = orderRepository.findById(outbound.getOrder().getOrderId())
+                .orElseThrow(() -> new OrderException(ORDER_NOT_FOUND));
+        order.updateShipped();
+        outbound.updateStatus(OutboundStatus.SHIPPED);
     }
 
     // 출고 목록 조회
@@ -88,7 +132,7 @@ public class OutboundService {
     }
 
     private Order verification(OutboundCreateDto dto) {
-        Member manager = memberRepository.findById(dto.getMemberId())
+        memberRepository.findById(dto.getMemberId())
                 .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
 
         Order order = orderRepository.findById(dto.getOrderId())
@@ -104,9 +148,9 @@ public class OutboundService {
         return order;
     }
 
-    private Outbound createBaseOutbound (OutboundCreateDto dto) {
+    private Outbound createBaseOutbound(OutboundCreateDto dto) {
         String OutboundCode = codeGenerator.generate(OUTBOUND_CODE_PREFIX);
-        OutboundStatus status = OutboundStatus.PENDING;
+        OutboundStatus status = OutboundStatus.REQUESTED;
 
         return dto.toEntity(OutboundCode, status);
     }
@@ -122,6 +166,11 @@ public class OutboundService {
 
             outboundProductItem.assignOutbound(outbound);
         });
+    }
+
+    private Outbound chekOutbound(Long id) {
+        return outboundRepository.findById(id)
+                .orElseThrow(() -> new OutboundException(OUTBOUND_NOT_FOUND));
     }
 
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/service/OutboundService.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/service/OutboundService.java
@@ -116,7 +116,7 @@ public class OutboundService {
             OutboundProductItem outboundProductItem = OutboundProductItem.builder()
                     .product(opItem.getProduct())
                     .orderProductItem(opItem)
-                    .receivedQuantity(opItem.getOrderedQuantity())
+                    .orderedQuantity(opItem.getOrderedQuantity())
                     .description(opItem.getDescription())
                     .build();
 


### PR DESCRIPTION
# 🧩 Issue
#36, #38
## 📝 요약
Outbound의 상태관리를 구현

## 🔍 변경 사항
- feat: Outbound 승인 
- feat: Outbound 취소
- feat: Outbound 검수
- feat: Outbound 출하 
```
    @Transactional
    public void updateShipped(Long id) {
        Outbound outbound = chekOutbound(id);
        Order order = orderRepository.findById(outbound.getOrder().getOrderId())
                .orElseThrow(() -> new OrderException(ORDER_NOT_FOUND));
        order.updateShipped();
        outbound.updateStatus(OutboundStatus.SHIPPED);
    }
```
출하시 Order의 상태도 동기화 되게 했습니다.

- 관련 이슈: * close #36, * close #38 


## ✅ 체크리스트
- [x] 코드 컨벤션을 준수 했는가?
- [x] 커밋 내용에 시크릿 키 등의 공유되지 말아야 할 것들을 제거 했는가?

## 💬 기타 공유사항
* #37 은 구체적으로 어떤 요구사항인지 모르겠어서 관련 이슈에 안넣었습니다.