### PR TITLE
Feat: Outbound 승인시 Task 생성 구현

### DIFF
--- a/src/main/java/com/fourweekdays/fourweekdays/inventory/model/entity/Inventory.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/inventory/model/entity/Inventory.java
@@ -74,4 +74,12 @@ public class Inventory extends BaseEntity {
         this.quantity -= amount;
         this.location.decreaseUsedCapacity(amount);
     }
+
+    public void decrease(int deducted) {
+        if (deducted < 0) {
+            throw new InventoryException(INVALID_QUANTITY);
+        }
+        this.quantity -= deducted;
+    }
+
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/inventory/repository/InventoryRepository.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/inventory/repository/InventoryRepository.java
@@ -29,4 +29,17 @@ public interface InventoryRepository extends JpaRepository<Inventory, Long>, Inv
     List<Inventory> findByLocationId(@Param("locationId") Long locationId);
 
     List<Inventory> findByInboundId(Long inboundId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            SELECT i FROM Inventory i
+            WHERE i.product.id = :productId
+            AND i.location.id = :locationId
+            ORDER BY i.lotNumber ASC
+            """)
+    List<Inventory> findByProductIdAndLocationIdOrderByLotNumberAscForUpdate(
+            @Param("productId") Long productId,
+            @Param("locationId") Long locationId
+    );
+
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/location/repository/LocationRepository.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/location/repository/LocationRepository.java
@@ -27,4 +27,8 @@ public interface LocationRepository extends JpaRepository<Location, Long> {
             "ORDER BY l.usedCapacity ASC")
     List<Location> findAvailableLocationsByVendor(@Param("vendorId") Long vendorId, @Param("minCapacity") int minCapacity);
 
+    // LocationRepository
+    @Query("SELECT l FROM Location l WHERE l.vendorId IN :vendorIds")
+    List<Location> findAllByVendorIds(@Param("vendorIds") List<Long> vendorIds);
+
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/model/entity/OutboundInventoryHistory.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/model/entity/OutboundInventoryHistory.java
@@ -1,0 +1,30 @@
+package com.fourweekdays.fourweekdays.outbound.model.entity;
+
+import com.fourweekdays.fourweekdays.inventory.model.entity.Inventory;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OutboundInventoryHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Outbound outbound;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Inventory inventory;
+
+    private int quantityChanged;
+    private String lotNumber;
+
+    @Enumerated(EnumType.STRING)
+    private OutboundInventoryHistoryStatus status;
+}

--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/model/entity/OutboundInventoryHistoryStatus.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/model/entity/OutboundInventoryHistoryStatus.java
@@ -1,0 +1,5 @@
+package com.fourweekdays.fourweekdays.outbound.model.entity;
+
+public enum OutboundInventoryHistoryStatus {
+    ACTIVE, RESTORED, CANCELLED
+}

--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/model/entity/OutboundStatus.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/model/entity/OutboundStatus.java
@@ -7,9 +7,9 @@ public enum OutboundStatus {
 
     REQUESTED("출고서 생성"),
     APPROVED("출고 예정"),
-    PICKING("피킹"),
-    INSPECTION("검수"),
-    PACKING("패킹"),
+    PICKING("피킹 완료"),
+    INSPECTION("검수 완료"),
+    PACKING("패킹 완료"),
     SHIPPED("출하 완료"), // 재고 감소
     CANCELLED("취소");
 

--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/repository/OutboundInventoryHistoryRepository.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/repository/OutboundInventoryHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.fourweekdays.fourweekdays.outbound.repository;
+
+import com.fourweekdays.fourweekdays.outbound.model.entity.OutboundInventoryHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OutboundInventoryHistoryRepository extends JpaRepository<OutboundInventoryHistory, Long> {
+}

--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/repository/OutboundRepository.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/repository/OutboundRepository.java
@@ -4,8 +4,6 @@ import com.fourweekdays.fourweekdays.order.model.entity.Order;
 import com.fourweekdays.fourweekdays.outbound.model.entity.Outbound;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface OutboundRepository extends JpaRepository<Outbound, Long> {
     boolean existsByOrder(Order order);
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/tasks/factory/OutboundTaskFactory.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/tasks/factory/OutboundTaskFactory.java
@@ -1,0 +1,68 @@
+package com.fourweekdays.fourweekdays.tasks.factory;
+
+import com.fourweekdays.fourweekdays.outbound.exception.OutboundException;
+import com.fourweekdays.fourweekdays.outbound.model.entity.Outbound;
+import com.fourweekdays.fourweekdays.outbound.repository.OutboundRepository;
+import com.fourweekdays.fourweekdays.outbound.service.OutboundService;
+import com.fourweekdays.fourweekdays.tasks.model.entity.Task;
+import com.fourweekdays.fourweekdays.tasks.model.entity.TaskCategory;
+import com.fourweekdays.fourweekdays.tasks.model.entity.TaskStatus;
+import com.fourweekdays.fourweekdays.tasks.repository.TaskRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.fourweekdays.fourweekdays.outbound.exception.OutboundExceptionType.OUTBOUND_NOT_FOUND;
+
+@RequiredArgsConstructor
+@Component
+public class OutboundTaskFactory {
+
+    private final TaskRepository taskRepository;
+    private final OutboundRepository outboundRepository;
+    private final OutboundService outboundService;
+
+    @Transactional
+    public Long createPickingTask(Long outboundId) {
+        Outbound outbound = outboundRepository.findById(outboundId)
+                .orElseThrow(() -> new OutboundException(OUTBOUND_NOT_FOUND));
+
+        Task task = createTask(TaskCategory.PICKING, outboundId);
+        // PickingTask를 만들어야 할 이유를 모르겠음
+        // 조회할때 Outbound -> OutboundProductItem -> Product -> Vendor -> Location
+        // 나중에 필요하다 생각되면 PickingTask를 만들어서 거기에 저장해두고 불러오게
+        // 검증도 마찬가지 Outbound -> OutboundProductItem -> Product -> Vendor -> Location
+        // 비효율적인것 같긴함
+
+        // TODO 제고 감소
+        outboundService.destroyOrDecreaseFromOutbound(outboundId);
+        return task.getId();
+    }
+
+    @Transactional
+    public Long createInspectionTask(Long outboundId) {
+        Outbound outbound = outboundRepository.findById(outboundId)
+                .orElseThrow(() -> new OutboundException(OUTBOUND_NOT_FOUND));
+
+        Task task = createTask(TaskCategory.INSPECTION, outboundId);
+        return task.getId();
+    }
+
+    @Transactional
+    public Long createPackingTask(Long outboundId) {
+        Outbound outbound = outboundRepository.findById(outboundId)
+                .orElseThrow(() -> new OutboundException(OUTBOUND_NOT_FOUND));
+
+        Task task = createTask(TaskCategory.PACKING, outboundId);
+        return task.getId();
+    }
+
+    private Task createTask(TaskCategory taskCategory, Long outboundId) {
+        Task task = Task.builder()
+                .category(taskCategory)
+                .status(TaskStatus.PENDING)
+                .referenceId(outboundId)
+                .build();
+        return taskRepository.save(task);
+    }
+}


### PR DESCRIPTION
# 🧩 Issue

## 📝 요약
Feat: Outbound 승인시 Task 생성 구현

## 🔍 변경 사항
- 1. 출고 승인
- 2. 출고 작업 생성
- 3. 재고 감소
- 4. 재고가 0이면 삭제하고 계속해서 다른 재고 감소

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수 했는가?
- [x] 커밋 내용에 시크릿 키 등의 공유되지 말아야 할 것들을 제거 했는가?

## 💬 기타 공유사항
작업이 승인될때 피킹에서 사용할 피킹엔티티를 만들까 고민했었는데 그냥 안만들기로 했습니다.
출고 상품에 대한 Locaion이 지정되어 있다고 생각하고 만들었습니다 기준은 lot번호가 오래된 순서로
그래서 locaion을 조회하는데 방식이 Ouboun -> OutboundProductItem -> Product -> Vendor -> Location 이래서 잘 하고 있는건지 모르겠다는 거고 제가 만든 재고 감소 로직자체가 팀원분들이 생각하신 내용과 동일한지도 모르겠군요
아무튼 이런 부분을 중점으로 봐주시면 수정하겠습니다.