### PR TITLE
[feat] asn 비즈니스 로직 및 엔티티 수정

### DIFF
--- a/src/main/java/com/fourweekdays/fourweekdays/asn/model/dto/response/AsnResponse.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/asn/model/dto/response/AsnResponse.java
@@ -4,15 +4,18 @@ import com.fourweekdays.fourweekdays.asn.model.entity.Asn;
 import com.fourweekdays.fourweekdays.purchaseorder.model.dto.response.PurchaseOrderProductResponseDto;
 import com.fourweekdays.fourweekdays.purchaseorder.model.entity.PurchaseOrder;
 import lombok.Builder;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Getter
 @Builder
 public class AsnResponse {
 
     private Long id;
     private String asnCode;
+    private String purchaseOrderCode;
     private String vendorName;
     private LocalDateTime expectedDate;
     private String description; // 비고
@@ -25,6 +28,7 @@ public class AsnResponse {
         return AsnResponse.builder()
                 .id(asn.getId())
                 .asnCode(asn.getAsnCode())
+                .purchaseOrderCode(purchaseOrder.getOrderCode())
                 .vendorName(asn.getVendor().getName())
                 .expectedDate(asn.getExpectedDate())
                 .description(asn.getDescription())

--- a/src/main/java/com/fourweekdays/fourweekdays/asn/model/entity/Asn.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/asn/model/entity/Asn.java
@@ -33,15 +33,18 @@ public class Asn extends BaseEntity {
 
     private String description; // 비고
 
+    @Enumerated(EnumType.STRING)
+    private AsnStatus status;
 
     public static Asn create(Vendor vendor, PurchaseOrder purchaseOrder,
-                             String asnCode, LocalDateTime expectedDate, String description) {
+                             String asnCode, LocalDateTime expectedDate, String description, AsnStatus status) {
         Asn asn = new Asn();
         asn.vendor = vendor;
         asn.purchaseOrder = purchaseOrder;
         asn.asnCode = asnCode;
         asn.expectedDate = expectedDate;
         asn.description = description;
+        asn.status = status;
         return asn;
     }
 

--- a/src/main/java/com/fourweekdays/fourweekdays/asn/model/entity/AsnStatus.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/asn/model/entity/AsnStatus.java
@@ -1,0 +1,15 @@
+package com.fourweekdays.fourweekdays.asn.model.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum AsnStatus {
+    ACCEPTED("ASN 승인"),
+    REJECTED("ASN 거절");
+
+    private final String description;
+
+    AsnStatus(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/fourweekdays/fourweekdays/asn/service/AsnVendorService.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/asn/service/AsnVendorService.java
@@ -5,6 +5,7 @@ import com.fourweekdays.fourweekdays.asn.model.dto.request.AsnReceiveRequest;
 import com.fourweekdays.fourweekdays.asn.model.dto.request.PurchaseOrderRejectRequest;
 import com.fourweekdays.fourweekdays.asn.model.dto.response.AsnReceiveResponse;
 import com.fourweekdays.fourweekdays.asn.model.entity.Asn;
+import com.fourweekdays.fourweekdays.asn.model.entity.AsnStatus;
 import com.fourweekdays.fourweekdays.asn.repository.AsnRepository;
 import com.fourweekdays.fourweekdays.common.generator.CodeGenerator;
 import com.fourweekdays.fourweekdays.inbound.service.InboundService;
@@ -50,7 +51,8 @@ public class AsnVendorService {
                 purchaseOrder,
                 codeGenerator.generate(ASN_CODE_PREFIX),
                 request.expectedDate(),
-                request.description()
+                request.description(),
+                AsnStatus.ACCEPTED
         );
         asnRepository.save(asn);
 
@@ -73,6 +75,17 @@ public class AsnVendorService {
         }
 
         purchaseOrder.rejectByVendor(request.description());
+
+        // reject된 발주건 테이블 저장
+        Asn rejectedAsn = Asn.create(
+                vendor,
+                purchaseOrder,
+                codeGenerator.generate(ASN_CODE_PREFIX),
+                null,
+                request.description(),
+                AsnStatus.REJECTED
+        );
+        asnRepository.save(rejectedAsn);
     }
 
 


### PR DESCRIPTION
# 🧩 Issue
* #188 
## 📝 요약
feat: asn 비즈니스 로직 및 엔티티 수정

## 🔍 변경 사항
- asn테이블에 발주서 승인/거절 상태 파악을 위해 asnStatus enum 타입 추가하면서 엔티티 수정했습니다.
- 외부업체로부터 회신받은 asn 목록에 발주 코드를 불러올 수 있게, AsnResponse 수정했습니다.
- * close #188 

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수 했는가?
- [x] 커밋 내용에 시크릿 키 등의 공유되지 말아야 할 것들을 제거 했는가?

## 💬 기타 공유사항
asn status는 노션에 기입된대로 postman으로 요청했고, db내 상태 변경되는점 확인 완료했습니다.