### PR TITLE
Refactor: 순환참조 에러수정

### DIFF
--- a/src/main/java/com/fourweekdays/fourweekdays/outbound/service/OutboundService.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/outbound/service/OutboundService.java
@@ -106,6 +106,8 @@ public class OutboundService {
 
         // 출고 작업 생성
         otfTaskFactory.createPickingTask(id);
+        destroyOrDecreaseFromOutbound(id);
+
     }
 
     // 출고 거절

--- a/src/main/java/com/fourweekdays/fourweekdays/tasks/factory/OutboundTaskFactory.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/tasks/factory/OutboundTaskFactory.java
@@ -20,7 +20,6 @@ public class OutboundTaskFactory {
 
     private final TaskRepository taskRepository;
     private final OutboundRepository outboundRepository;
-    private final OutboundService outboundService;
 
     @Transactional
     public Long createPickingTask(Long outboundId) {
@@ -28,14 +27,6 @@ public class OutboundTaskFactory {
                 .orElseThrow(() -> new OutboundException(OUTBOUND_NOT_FOUND));
 
         Task task = createTask(TaskCategory.PICKING, outboundId);
-        // PickingTask를 만들어야 할 이유를 모르겠음
-        // 조회할때 Outbound -> OutboundProductItem -> Product -> Vendor -> Location
-        // 나중에 필요하다 생각되면 PickingTask를 만들어서 거기에 저장해두고 불러오게
-        // 검증도 마찬가지 Outbound -> OutboundProductItem -> Product -> Vendor -> Location
-        // 비효율적인것 같긴함
-
-        // TODO 제고 감소
-        outboundService.destroyOrDecreaseFromOutbound(outboundId);
         return task.getId();
     }
 


### PR DESCRIPTION
# 🧩 Issue

## 📝 요약
OutboundTaskFactory, outboundService가 서로를 참조하는 상황 발생 이를 수정

## 🔍 변경 사항
- 메소드 호출 위치만 변경함

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수 했는가?
- [x] 커밋 내용에 시크릿 키 등의 공유되지 말아야 할 것들을 제거 했는가?