### PR TITLE
fix: 로그인/로그아웃 로직을 수정한다.

### DIFF
--- a/src/main/java/com/fourweekdays/fourweekdays/member/config/filter/LoginFilter.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/member/config/filter/LoginFilter.java
@@ -5,13 +5,11 @@ import com.fourweekdays.fourweekdays.common.BaseResponse;
 import com.fourweekdays.fourweekdays.member.config.utils.JwtUtil;
 import com.fourweekdays.fourweekdays.member.model.UserAuth;
 import com.fourweekdays.fourweekdays.member.model.dto.MemberLoginDto;
-import com.fourweekdays.fourweekdays.member.model.dto.MemberLoginResponseDto;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -21,10 +19,14 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import java.io.IOException;
 import java.util.Map;
 
-@RequiredArgsConstructor
 public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
     private final AuthenticationManager authenticationManager;
+
+    public LoginFilter(AuthenticationManager authenticationManager, String loginUrl) {
+        this.authenticationManager = authenticationManager;
+        setFilterProcessesUrl(loginUrl);
+    }
 
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
@@ -70,7 +72,6 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
                     )
             );
         }
-
 
     }
 }

--- a/src/main/java/com/fourweekdays/fourweekdays/member/config/handler/CustomLogoutSuccessHandler.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/member/config/handler/CustomLogoutSuccessHandler.java
@@ -1,0 +1,35 @@
+package com.fourweekdays.fourweekdays.member.config.handler;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fourweekdays.fourweekdays.common.BaseResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+
+import java.io.IOException;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class CustomLogoutSuccessHandler implements LogoutSuccessHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onLogoutSuccess(HttpServletRequest request,
+                                HttpServletResponse response,
+                                Authentication authentication) throws IOException, ServletException {
+
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType("application/json; charset=UTF-8");
+
+        BaseResponse<Map<String, Object>> logout = BaseResponse.success(Map.of(
+                "message", "로그아웃에 성공하였습니다."
+        ));
+
+        objectMapper.writeValue(response.getWriter(), logout);
+    }
+}

--- a/src/main/java/com/fourweekdays/fourweekdays/member/config/utils/JwtUtil.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/member/config/utils/JwtUtil.java
@@ -15,7 +15,7 @@ public class JwtUtil {
 
     private static final String SECRET = "abcdeffghijklmnopqrstuvwxyz0123456";
     private static final Key KEY = Keys.hmacShaKeyFor(SECRET.getBytes());
-    private static final Long EXP = 1000 * 60 * 10L;
+    private static final Long EXP = 1000 * 60 * 30L;
 
     public static final String IDX_NAME = "idx";
     public static final String EMAIL_NAME = "email";


### PR DESCRIPTION
# 🧩 Issue
- #216 

## 📝 요약
- 인증 로직을 변경하였습니다.

## 🔍 변경 사항
- 로그인 경로를 /login에서 리버스 프록시 경로에 맞춰 /api/login 으로 변경
- 로그아웃 경로를 /logout에서 리버스 프록시 경로에 맞춰 /api/logout 으로 변경
- 로그아웃 커스텀 핸들러 추가
- close #216 

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수 했는가?
- [x] 커밋 내용에 시크릿 키 등의 공유되지 말아야 할 것들을 제거 했는가?
