### PR TITLE
feat : springConfig에 권한별로 접근하게 설정

### DIFF
--- a/src/main/java/com/fourweekdays/fourweekdays/member/config/filter/JwtAuthFilter.java
+++ b/src/main/java/com/fourweekdays/fourweekdays/member/config/filter/JwtAuthFilter.java
@@ -67,7 +67,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                     Authentication authentication = new UsernamePasswordAuthenticationToken(
                             authUser,
                             null,
-                            List.of(new SimpleGrantedAuthority(role))
+                            List.of(new SimpleGrantedAuthority("ROLE_" + role))
                     );
 
                     // SecurityContext에 Authentication 객체 저장


### PR DESCRIPTION
# 🧩 Issue
* #223 
## 📝 요약
springConfig에 권한별로 접근하게 추가함.

## 🔍 변경 사항
- config에 권한별 접근 기능 추가, 권한 이름을 못읽어서 읽을 수 있게  바꿧습니다.
- close #223 

기본적으로 관리자는 다 접근 가능
Dashboard - 관리자,매니저
annuoncement-매니저 , 관리자 생성 수정등등
purchase(발주) -매니저
inbound(입고) - 매니저
outbound(출고)-매니저
inventory(재고)-매니저
product(상품) - 매니저, 상품등록,수정 관리자
vender(공급업체)-매니저, 공급업체 등록,수정 관리자
franchise(가맹점)- 매니저 , 가맹점 등록,수정 관리자
employee(직원) - 매니저, 등록이나 권한,수정은 관리자
taks(작업) - 매니저 ,worker
warehous(물류창고) - 매니저 ,등록 수정은 관리자.
이렇게 생각하고 넣었습니다.

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수 했는가?
- [ ] 커밋 내용에 시크릿 키 등의 공유되지 말아야 할 것들을 제거 했는가?

## 💬 기타 공유사항